### PR TITLE
Adding debug for invalid events

### DIFF
--- a/hook.js
+++ b/hook.js
@@ -24,6 +24,9 @@ function handle(request, response) {
         logger.log(metadata);
         comment(metadata);
     }
+    else {
+        logger.logError('Invalid event received: ' + eventType);
+    }
 }
 
 function comment(metadata) {


### PR DESCRIPTION
We should keep track of invalid types to see if people are using the tool wrong.