### PR TITLE
Fix issue 70 - Improve logger functions

### DIFF
--- a/hook.js
+++ b/hook.js
@@ -24,7 +24,7 @@ function handle(request, response) {
     if (eventType === 'pull_request') {
         originRepo = metadata.pull_request.head.repo.full_name;
 
-        logger.log(metadata);
+        logger.log('Pull request received:', metadata);
         trackUsage(originRepo);
 
         addPullRequestComments(
@@ -43,10 +43,10 @@ function addPullRequestComments(destinationRepo, originRepo, originBranch, prNum
 
         getPullRequestCommits(destinationRepo, prNumber, function(error, commits) {
 
-            if (error) return logger.logError(error);
+            if (error) return logger.error('getPullRequestCommits failed:', error);
             commits.forEach(function(currentCommit) {
                 getCommitDetail(originRepo, currentCommit.sha, function(error, currentCommitDetail) {
-                    if (error) return logger.logError(error);
+                    if (error) return logger.error('getCommitDetail failed:', error);
                     parseCSS(currentCommitDetail.files, config, commentURL, token, function(usageInfo) {}, currentCommit.sha);
                 });
             });
@@ -89,7 +89,7 @@ function getCommitDetail(repo, sha, callback) {
 }
 
 function trackUsage(repo) {
-    logger.log(repo, 'Compatibility test requested from:');
+    logger.log('Compatibility test requested from:', repo);
 }
 
 var parseCSS = function(files, config, commentURL, token, cb, sha) {
@@ -137,7 +137,7 @@ var renderComment = function(url, file, comment, position, token, sha) {
             position: position
         })
     }, function(error, response, body) {
-        if (error) return logger.logError(error);
+        if (error) return logger.error('renderComment/sendRequest failed:', error);
     });
 };
 

--- a/logger.js
+++ b/logger.js
@@ -1,16 +1,10 @@
 'use strict';
 
-function log(data, title, logger) {
-    logger = logger || console.log;
+['log', 'warn', 'error'].forEach(function(level) {
+    exports[level] = function() {
+        var args = Array.prototype.slice.call(arguments);
+        args.unshift('[' + level + ']');
 
-    logger(title || 'Debug:');
-    logger(data);
-}
-
-function logError(error, title) {
-    title = title || 'Error:';
-    log(error.stack, title, console.error);
-}
-
-exports.log = log;
-exports.logError = logError;
+        console[level].apply(console, args);
+    };
+});


### PR DESCRIPTION
Smaller, sweeter logging functions.

```
logger.log('whatever');
logger.warn('whatever else');
logger.error('oh noooo');

logger.error('one', 'two', 'three');
```