### PR TITLE
Move Buffer handling to utils file with simple function

### DIFF
--- a/hook.js
+++ b/hook.js
@@ -3,10 +3,12 @@
 var github = require('octonode');
 var path = require('path');
 var Q = require('q');
+
 var commenter = require('./commenter');
 var diff = require('./diffParse');
 var logger = require('./logger');
 var processor = require('./processor');
+var utils = require('./utils');
 
 var configFilename = '.doiuse';
 var githubClient = github.client();
@@ -94,9 +96,7 @@ function getConfig(repo, branch) {
         // Only replace the default config if the .doiuse file exists and has content
         if (!error && configFileMetadata.content) {
             // Consider text separated by commas and linebreaks to be individual options
-            config = new Buffer(configFileMetadata.content, 'base64').toString()
-                .replace(/\r?\n|\r/g, ', ')
-                .split(/,\s*/);
+            config = utils.prepareContent(configFileMetadata.content).replace(/\r?\n|\r/g, ', ').split(/,\s*/);
         }
 
         deferred.resolve(config);

--- a/processor.js
+++ b/processor.js
@@ -5,7 +5,9 @@ var github = require('octonode');
 var postcss = require('postcss');
 var sourceMap = require('source-map');
 var stylus = require('stylus');
+
 var logger = require('./logger');
+var utils = require('./utils');
 
 /**
  * Test and report on changes to the given CSS stylesheet.
@@ -19,7 +21,7 @@ function processCSS(repo, branch, file, config, handleIncompatibility) {
 
         if (error) return logger.error('Error reading contents from ' + repo + ' / ' + branch + ' / ' + file.filename + ':', error);
 
-        fileContents = new Buffer(fileContentsMetadata.content, 'base64').toString();
+        fileContents = utils.prepareContent(fileContentsMetadata.content);
 
         // Test the stylesheet with doiuse and call handleIncompatibility for
         // any incompatibilities that are found
@@ -44,7 +46,7 @@ function processStylus(repo, branch, file, config, handleIncompatibility) {
 
         if (error) return logger.error('Error reading contents from ' + repo + ' / ' + branch + ' / ' + file.filename + ':', error);
 
-        fileContents = new Buffer(fileContentsMetadata.content, 'base64').toString();
+        fileContents = utils.prepareContent(fileContentsMetadata.content);
         compiler = stylus(fileContents)
             .set('filename', file.filename)
             .set('sourcemap', {});

--- a/utils.js
+++ b/utils.js
@@ -1,0 +1,10 @@
+'use strict';
+
+/**
+ * Format blob content received by GitHub for processing within Discord
+ */
+function prepareContent(content) {
+    return new Buffer(content, 'base64').toString();
+}
+
+exports.prepareContent = prepareContent;


### PR DESCRIPTION
`new Buffer(str, 'base64').toString();` is repeated a bunch so we should move it to its own wrapper function