### PR TITLE
Begin shrink-wrapping dependencies

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,6 +25,12 @@ changes and execute Discord on your test repository code!  If warnings are found
 by Discord, they will show up as comments within the commit detail screen on
 GitHub.
 
+# Changing dependencies
+
+Use exact versions for dependencies in *package.json*. Always run `npm
+shrinkwrap` and commit *npm-shrinkwrap.json* after changing dependencies. Run
+`npm help shrinkwrap` for more information.
+
 # Submitting a pull request
 
 Before submitting a pull request, run the following commands to test your

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,0 +1,2577 @@
+{
+    "name": "Discord",
+    "dependencies": {
+        "body-parser": {
+            "version": "1.6.6",
+            "from": "body-parser@1.6.6",
+            "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.6.6.tgz",
+            "dependencies": {
+                "bytes": {
+                    "version": "1.0.0",
+                    "from": "bytes@1.0.0",
+                    "resolved": "https://registry.npmjs.org/bytes/-/bytes-1.0.0.tgz"
+                },
+                "depd": {
+                    "version": "0.4.4",
+                    "from": "depd@0.4.4",
+                    "resolved": "https://registry.npmjs.org/depd/-/depd-0.4.4.tgz"
+                },
+                "iconv-lite": {
+                    "version": "0.4.4",
+                    "from": "iconv-lite@0.4.4",
+                    "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.4.tgz"
+                },
+                "media-typer": {
+                    "version": "0.2.0",
+                    "from": "media-typer@0.2.0",
+                    "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.2.0.tgz"
+                },
+                "on-finished": {
+                    "version": "2.1.0",
+                    "from": "on-finished@2.1.0",
+                    "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.1.0.tgz",
+                    "dependencies": {
+                        "ee-first": {
+                            "version": "1.0.5",
+                            "from": "ee-first@1.0.5",
+                            "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.0.5.tgz"
+                        }
+                    }
+                },
+                "qs": {
+                    "version": "2.2.0",
+                    "from": "qs@2.2.0",
+                    "resolved": "https://registry.npmjs.org/qs/-/qs-2.2.0.tgz"
+                },
+                "raw-body": {
+                    "version": "1.3.0",
+                    "from": "raw-body@1.3.0",
+                    "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-1.3.0.tgz"
+                },
+                "type-is": {
+                    "version": "1.3.2",
+                    "from": "type-is@>=1.3.2 <1.4.0",
+                    "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.3.2.tgz",
+                    "dependencies": {
+                        "mime-types": {
+                            "version": "1.0.2",
+                            "from": "mime-types@>=1.0.1 <1.1.0",
+                            "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-1.0.2.tgz"
+                        }
+                    }
+                }
+            }
+        },
+        "doiuse": {
+            "version": "1.0.2",
+            "from": "doiuse@1.0.2",
+            "resolved": "https://registry.npmjs.org/doiuse/-/doiuse-1.0.2.tgz",
+            "dependencies": {
+                "browserslist": {
+                    "version": "0.3.3",
+                    "from": "browserslist@>=0.3.1 <0.4.0",
+                    "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-0.3.3.tgz"
+                },
+                "caniuse-db": {
+                    "version": "1.0.30000222",
+                    "from": "caniuse-db@>=1.0.30000187 <2.0.0",
+                    "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000222.tgz"
+                },
+                "css-rule-stream": {
+                    "version": "1.1.0",
+                    "from": "css-rule-stream@>=1.1.0 <2.0.0",
+                    "resolved": "https://registry.npmjs.org/css-rule-stream/-/css-rule-stream-1.1.0.tgz",
+                    "dependencies": {
+                        "css-tokenize": {
+                            "version": "1.0.1",
+                            "from": "css-tokenize@>=1.0.1 <2.0.0",
+                            "resolved": "https://registry.npmjs.org/css-tokenize/-/css-tokenize-1.0.1.tgz",
+                            "dependencies": {
+                                "inherits": {
+                                    "version": "2.0.1",
+                                    "from": "inherits@>=2.0.1 <3.0.0",
+                                    "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                                },
+                                "readable-stream": {
+                                    "version": "1.1.13",
+                                    "from": "readable-stream@>=1.0.33 <2.0.0",
+                                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
+                                    "dependencies": {
+                                        "core-util-is": {
+                                            "version": "1.0.1",
+                                            "from": "core-util-is@>=1.0.0 <1.1.0",
+                                            "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                                        },
+                                        "isarray": {
+                                            "version": "0.0.1",
+                                            "from": "isarray@0.0.1",
+                                            "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                                        },
+                                        "string_decoder": {
+                                            "version": "0.10.31",
+                                            "from": "string_decoder@>=0.10.0 <0.11.0",
+                                            "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "duplexer2": {
+                    "version": "0.0.2",
+                    "from": "duplexer2@0.0.2",
+                    "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.0.2.tgz",
+                    "dependencies": {
+                        "readable-stream": {
+                            "version": "1.1.13",
+                            "from": "readable-stream@>=1.1.9 <1.2.0",
+                            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
+                            "dependencies": {
+                                "core-util-is": {
+                                    "version": "1.0.1",
+                                    "from": "core-util-is@>=1.0.0 <1.1.0",
+                                    "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                                },
+                                "isarray": {
+                                    "version": "0.0.1",
+                                    "from": "isarray@0.0.1",
+                                    "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                                },
+                                "string_decoder": {
+                                    "version": "0.10.31",
+                                    "from": "string_decoder@>=0.10.0 <0.11.0",
+                                    "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                                },
+                                "inherits": {
+                                    "version": "2.0.1",
+                                    "from": "inherits@>=2.0.1 <2.1.0",
+                                    "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                                }
+                            }
+                        }
+                    }
+                },
+                "jsonfilter": {
+                    "version": "1.1.2",
+                    "from": "jsonfilter@>=1.1.2 <2.0.0",
+                    "resolved": "https://registry.npmjs.org/jsonfilter/-/jsonfilter-1.1.2.tgz",
+                    "dependencies": {
+                        "JSONStream": {
+                            "version": "0.8.4",
+                            "from": "JSONStream@>=0.8.4 <0.9.0",
+                            "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-0.8.4.tgz",
+                            "dependencies": {
+                                "jsonparse": {
+                                    "version": "0.0.5",
+                                    "from": "jsonparse@0.0.5",
+                                    "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-0.0.5.tgz"
+                                },
+                                "through": {
+                                    "version": "2.3.8",
+                                    "from": "through@>=2.2.7 <3.0.0",
+                                    "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz"
+                                }
+                            }
+                        },
+                        "stream-combiner": {
+                            "version": "0.2.2",
+                            "from": "stream-combiner@>=0.2.1 <0.3.0",
+                            "resolved": "https://registry.npmjs.org/stream-combiner/-/stream-combiner-0.2.2.tgz",
+                            "dependencies": {
+                                "duplexer": {
+                                    "version": "0.1.1",
+                                    "from": "duplexer@>=0.1.1 <0.2.0",
+                                    "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz"
+                                },
+                                "through": {
+                                    "version": "2.3.8",
+                                    "from": "through@>=2.3.1 <2.4.0",
+                                    "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz"
+                                }
+                            }
+                        },
+                        "minimist": {
+                            "version": "1.1.1",
+                            "from": "minimist@>=1.1.0 <2.0.0",
+                            "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.1.1.tgz"
+                        }
+                    }
+                },
+                "ldjson-stream": {
+                    "version": "1.2.1",
+                    "from": "ldjson-stream@>=1.2.1 <2.0.0",
+                    "resolved": "https://registry.npmjs.org/ldjson-stream/-/ldjson-stream-1.2.1.tgz",
+                    "dependencies": {
+                        "split2": {
+                            "version": "0.2.1",
+                            "from": "split2@>=0.2.1 <0.3.0",
+                            "resolved": "https://registry.npmjs.org/split2/-/split2-0.2.1.tgz"
+                        }
+                    }
+                },
+                "lodash": {
+                    "version": "3.10.0",
+                    "from": "lodash@>=3.5.0 <4.0.0",
+                    "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.0.tgz"
+                },
+                "through2": {
+                    "version": "0.6.5",
+                    "from": "through2@>=0.6.1 <0.7.0",
+                    "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
+                    "dependencies": {
+                        "readable-stream": {
+                            "version": "1.0.33",
+                            "from": "readable-stream@>=1.0.33-1 <1.1.0-0",
+                            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
+                            "dependencies": {
+                                "core-util-is": {
+                                    "version": "1.0.1",
+                                    "from": "core-util-is@>=1.0.0 <1.1.0",
+                                    "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                                },
+                                "isarray": {
+                                    "version": "0.0.1",
+                                    "from": "isarray@0.0.1",
+                                    "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                                },
+                                "string_decoder": {
+                                    "version": "0.10.31",
+                                    "from": "string_decoder@>=0.10.0 <0.11.0",
+                                    "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                                },
+                                "inherits": {
+                                    "version": "2.0.1",
+                                    "from": "inherits@>=2.0.1 <2.1.0",
+                                    "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                                }
+                            }
+                        },
+                        "xtend": {
+                            "version": "4.0.0",
+                            "from": "xtend@>=4.0.0 <4.1.0",
+                            "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz"
+                        }
+                    }
+                },
+                "yargs": {
+                    "version": "3.15.0",
+                    "from": "yargs@>=3.5.4 <4.0.0",
+                    "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.15.0.tgz",
+                    "dependencies": {
+                        "camelcase": {
+                            "version": "1.1.0",
+                            "from": "camelcase@>=1.0.2 <2.0.0",
+                            "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.1.0.tgz"
+                        },
+                        "cliui": {
+                            "version": "2.1.0",
+                            "from": "cliui@>=2.1.0 <3.0.0",
+                            "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
+                            "dependencies": {
+                                "center-align": {
+                                    "version": "0.1.1",
+                                    "from": "center-align@>=0.1.1 <0.2.0",
+                                    "resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.1.tgz",
+                                    "dependencies": {
+                                        "align-text": {
+                                            "version": "0.1.3",
+                                            "from": "align-text@>=0.1.0 <0.2.0",
+                                            "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.3.tgz",
+                                            "dependencies": {
+                                                "kind-of": {
+                                                    "version": "2.0.0",
+                                                    "from": "kind-of@>=2.0.0 <3.0.0",
+                                                    "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-2.0.0.tgz"
+                                                },
+                                                "longest": {
+                                                    "version": "1.0.1",
+                                                    "from": "longest@>=1.0.1 <2.0.0",
+                                                    "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz"
+                                                },
+                                                "repeat-string": {
+                                                    "version": "1.5.2",
+                                                    "from": "repeat-string@>=1.5.2 <2.0.0",
+                                                    "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.2.tgz"
+                                                }
+                                            }
+                                        }
+                                    }
+                                },
+                                "right-align": {
+                                    "version": "0.1.3",
+                                    "from": "right-align@>=0.1.1 <0.2.0",
+                                    "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
+                                    "dependencies": {
+                                        "align-text": {
+                                            "version": "0.1.3",
+                                            "from": "align-text@>=0.1.0 <0.2.0",
+                                            "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.3.tgz",
+                                            "dependencies": {
+                                                "kind-of": {
+                                                    "version": "2.0.0",
+                                                    "from": "kind-of@>=2.0.0 <3.0.0",
+                                                    "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-2.0.0.tgz"
+                                                },
+                                                "longest": {
+                                                    "version": "1.0.1",
+                                                    "from": "longest@>=1.0.1 <2.0.0",
+                                                    "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz"
+                                                },
+                                                "repeat-string": {
+                                                    "version": "1.5.2",
+                                                    "from": "repeat-string@>=1.5.2 <2.0.0",
+                                                    "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.2.tgz"
+                                                }
+                                            }
+                                        }
+                                    }
+                                },
+                                "wordwrap": {
+                                    "version": "0.0.2",
+                                    "from": "wordwrap@0.0.2",
+                                    "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
+                                }
+                            }
+                        },
+                        "decamelize": {
+                            "version": "1.0.0",
+                            "from": "decamelize@>=1.0.0 <2.0.0",
+                            "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.0.0.tgz"
+                        },
+                        "window-size": {
+                            "version": "0.1.2",
+                            "from": "window-size@>=0.1.1 <0.2.0",
+                            "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.2.tgz"
+                        }
+                    }
+                }
+            }
+        },
+        "express": {
+            "version": "4.8.6",
+            "from": "express@4.8.6",
+            "resolved": "https://registry.npmjs.org/express/-/express-4.8.6.tgz",
+            "dependencies": {
+                "accepts": {
+                    "version": "1.0.7",
+                    "from": "accepts@>=1.0.7 <1.1.0",
+                    "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.0.7.tgz",
+                    "dependencies": {
+                        "mime-types": {
+                            "version": "1.0.2",
+                            "from": "mime-types@>=1.0.0 <1.1.0",
+                            "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-1.0.2.tgz"
+                        },
+                        "negotiator": {
+                            "version": "0.4.7",
+                            "from": "negotiator@0.4.7",
+                            "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.4.7.tgz"
+                        }
+                    }
+                },
+                "buffer-crc32": {
+                    "version": "0.2.3",
+                    "from": "buffer-crc32@0.2.3",
+                    "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.3.tgz"
+                },
+                "debug": {
+                    "version": "1.0.4",
+                    "from": "debug@1.0.4",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-1.0.4.tgz",
+                    "dependencies": {
+                        "ms": {
+                            "version": "0.6.2",
+                            "from": "ms@0.6.2",
+                            "resolved": "https://registry.npmjs.org/ms/-/ms-0.6.2.tgz"
+                        }
+                    }
+                },
+                "depd": {
+                    "version": "0.4.4",
+                    "from": "depd@0.4.4",
+                    "resolved": "https://registry.npmjs.org/depd/-/depd-0.4.4.tgz"
+                },
+                "escape-html": {
+                    "version": "1.0.1",
+                    "from": "escape-html@1.0.1",
+                    "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.1.tgz"
+                },
+                "finalhandler": {
+                    "version": "0.1.0",
+                    "from": "finalhandler@0.1.0",
+                    "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-0.1.0.tgz"
+                },
+                "media-typer": {
+                    "version": "0.2.0",
+                    "from": "media-typer@0.2.0",
+                    "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.2.0.tgz"
+                },
+                "methods": {
+                    "version": "1.1.0",
+                    "from": "methods@1.1.0",
+                    "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.0.tgz"
+                },
+                "parseurl": {
+                    "version": "1.3.0",
+                    "from": "parseurl@>=1.3.0 <1.4.0",
+                    "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.0.tgz"
+                },
+                "path-to-regexp": {
+                    "version": "0.1.3",
+                    "from": "path-to-regexp@0.1.3",
+                    "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.3.tgz"
+                },
+                "proxy-addr": {
+                    "version": "1.0.1",
+                    "from": "proxy-addr@1.0.1",
+                    "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-1.0.1.tgz",
+                    "dependencies": {
+                        "ipaddr.js": {
+                            "version": "0.1.2",
+                            "from": "ipaddr.js@0.1.2",
+                            "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-0.1.2.tgz"
+                        }
+                    }
+                },
+                "qs": {
+                    "version": "2.2.0",
+                    "from": "qs@2.2.0",
+                    "resolved": "https://registry.npmjs.org/qs/-/qs-2.2.0.tgz"
+                },
+                "range-parser": {
+                    "version": "1.0.0",
+                    "from": "range-parser@1.0.0",
+                    "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.0.0.tgz"
+                },
+                "send": {
+                    "version": "0.8.3",
+                    "from": "send@0.8.3",
+                    "resolved": "https://registry.npmjs.org/send/-/send-0.8.3.tgz",
+                    "dependencies": {
+                        "destroy": {
+                            "version": "1.0.3",
+                            "from": "destroy@1.0.3",
+                            "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.3.tgz"
+                        },
+                        "mime": {
+                            "version": "1.2.11",
+                            "from": "mime@1.2.11",
+                            "resolved": "https://registry.npmjs.org/mime/-/mime-1.2.11.tgz"
+                        },
+                        "ms": {
+                            "version": "0.6.2",
+                            "from": "ms@0.6.2",
+                            "resolved": "https://registry.npmjs.org/ms/-/ms-0.6.2.tgz"
+                        },
+                        "on-finished": {
+                            "version": "2.1.0",
+                            "from": "on-finished@2.1.0",
+                            "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.1.0.tgz",
+                            "dependencies": {
+                                "ee-first": {
+                                    "version": "1.0.5",
+                                    "from": "ee-first@1.0.5",
+                                    "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.0.5.tgz"
+                                }
+                            }
+                        }
+                    }
+                },
+                "serve-static": {
+                    "version": "1.5.4",
+                    "from": "serve-static@>=1.5.3 <1.6.0",
+                    "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.5.4.tgz",
+                    "dependencies": {
+                        "send": {
+                            "version": "0.8.5",
+                            "from": "send@0.8.5",
+                            "resolved": "https://registry.npmjs.org/send/-/send-0.8.5.tgz",
+                            "dependencies": {
+                                "destroy": {
+                                    "version": "1.0.3",
+                                    "from": "destroy@1.0.3",
+                                    "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.3.tgz"
+                                },
+                                "mime": {
+                                    "version": "1.2.11",
+                                    "from": "mime@1.2.11",
+                                    "resolved": "https://registry.npmjs.org/mime/-/mime-1.2.11.tgz"
+                                },
+                                "ms": {
+                                    "version": "0.6.2",
+                                    "from": "ms@0.6.2",
+                                    "resolved": "https://registry.npmjs.org/ms/-/ms-0.6.2.tgz"
+                                },
+                                "on-finished": {
+                                    "version": "2.1.0",
+                                    "from": "on-finished@2.1.0",
+                                    "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.1.0.tgz",
+                                    "dependencies": {
+                                        "ee-first": {
+                                            "version": "1.0.5",
+                                            "from": "ee-first@1.0.5",
+                                            "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.0.5.tgz"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "type-is": {
+                    "version": "1.3.2",
+                    "from": "type-is@>=1.3.2 <1.4.0",
+                    "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.3.2.tgz",
+                    "dependencies": {
+                        "mime-types": {
+                            "version": "1.0.2",
+                            "from": "mime-types@>=1.0.0 <1.1.0",
+                            "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-1.0.2.tgz"
+                        }
+                    }
+                },
+                "vary": {
+                    "version": "0.1.0",
+                    "from": "vary@0.1.0",
+                    "resolved": "https://registry.npmjs.org/vary/-/vary-0.1.0.tgz"
+                },
+                "cookie": {
+                    "version": "0.1.2",
+                    "from": "cookie@0.1.2",
+                    "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.1.2.tgz"
+                },
+                "fresh": {
+                    "version": "0.2.2",
+                    "from": "fresh@0.2.2",
+                    "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.2.2.tgz"
+                },
+                "cookie-signature": {
+                    "version": "1.0.4",
+                    "from": "cookie-signature@1.0.4",
+                    "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.4.tgz"
+                },
+                "merge-descriptors": {
+                    "version": "0.0.2",
+                    "from": "merge-descriptors@0.0.2",
+                    "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-0.0.2.tgz"
+                },
+                "utils-merge": {
+                    "version": "1.0.0",
+                    "from": "utils-merge@1.0.0",
+                    "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.0.tgz"
+                }
+            }
+        },
+        "gulp": {
+            "version": "3.8.11",
+            "from": "gulp@3.8.11",
+            "resolved": "https://registry.npmjs.org/gulp/-/gulp-3.8.11.tgz",
+            "dependencies": {
+                "archy": {
+                    "version": "1.0.0",
+                    "from": "archy@>=1.0.0 <2.0.0",
+                    "resolved": "https://registry.npmjs.org/archy/-/archy-1.0.0.tgz"
+                },
+                "chalk": {
+                    "version": "0.5.1",
+                    "from": "chalk@>=0.5.0 <0.6.0",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.5.1.tgz",
+                    "dependencies": {
+                        "ansi-styles": {
+                            "version": "1.1.0",
+                            "from": "ansi-styles@>=1.1.0 <2.0.0",
+                            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.1.0.tgz"
+                        },
+                        "escape-string-regexp": {
+                            "version": "1.0.3",
+                            "from": "escape-string-regexp@>=1.0.0 <2.0.0",
+                            "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
+                        },
+                        "has-ansi": {
+                            "version": "0.1.0",
+                            "from": "has-ansi@>=0.1.0 <0.2.0",
+                            "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-0.1.0.tgz",
+                            "dependencies": {
+                                "ansi-regex": {
+                                    "version": "0.2.1",
+                                    "from": "ansi-regex@>=0.2.1 <0.3.0",
+                                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
+                                }
+                            }
+                        },
+                        "strip-ansi": {
+                            "version": "0.3.0",
+                            "from": "strip-ansi@>=0.3.0 <0.4.0",
+                            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.3.0.tgz",
+                            "dependencies": {
+                                "ansi-regex": {
+                                    "version": "0.2.1",
+                                    "from": "ansi-regex@>=0.2.1 <0.3.0",
+                                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
+                                }
+                            }
+                        },
+                        "supports-color": {
+                            "version": "0.2.0",
+                            "from": "supports-color@>=0.2.0 <0.3.0",
+                            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-0.2.0.tgz"
+                        }
+                    }
+                },
+                "deprecated": {
+                    "version": "0.0.1",
+                    "from": "deprecated@>=0.0.1 <0.0.2",
+                    "resolved": "https://registry.npmjs.org/deprecated/-/deprecated-0.0.1.tgz"
+                },
+                "gulp-util": {
+                    "version": "3.0.6",
+                    "from": "gulp-util@>=3.0.4 <4.0.0",
+                    "resolved": "https://registry.npmjs.org/gulp-util/-/gulp-util-3.0.6.tgz",
+                    "dependencies": {
+                        "array-differ": {
+                            "version": "1.0.0",
+                            "from": "array-differ@>=1.0.0 <2.0.0",
+                            "resolved": "https://registry.npmjs.org/array-differ/-/array-differ-1.0.0.tgz"
+                        },
+                        "array-uniq": {
+                            "version": "1.0.2",
+                            "from": "array-uniq@>=1.0.2 <2.0.0",
+                            "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.2.tgz"
+                        },
+                        "beeper": {
+                            "version": "1.1.0",
+                            "from": "beeper@>=1.0.0 <2.0.0",
+                            "resolved": "https://registry.npmjs.org/beeper/-/beeper-1.1.0.tgz"
+                        },
+                        "chalk": {
+                            "version": "1.1.0",
+                            "from": "chalk@>=1.0.0 <2.0.0",
+                            "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.0.tgz",
+                            "dependencies": {
+                                "ansi-styles": {
+                                    "version": "2.1.0",
+                                    "from": "ansi-styles@>=2.1.0 <3.0.0",
+                                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz"
+                                },
+                                "escape-string-regexp": {
+                                    "version": "1.0.3",
+                                    "from": "escape-string-regexp@>=1.0.2 <2.0.0",
+                                    "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
+                                },
+                                "has-ansi": {
+                                    "version": "2.0.0",
+                                    "from": "has-ansi@>=2.0.0 <3.0.0",
+                                    "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+                                    "dependencies": {
+                                        "ansi-regex": {
+                                            "version": "2.0.0",
+                                            "from": "ansi-regex@>=2.0.0 <3.0.0",
+                                            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
+                                        }
+                                    }
+                                },
+                                "strip-ansi": {
+                                    "version": "3.0.0",
+                                    "from": "strip-ansi@>=3.0.0 <4.0.0",
+                                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
+                                    "dependencies": {
+                                        "ansi-regex": {
+                                            "version": "2.0.0",
+                                            "from": "ansi-regex@>=2.0.0 <3.0.0",
+                                            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
+                                        }
+                                    }
+                                },
+                                "supports-color": {
+                                    "version": "2.0.0",
+                                    "from": "supports-color@>=2.0.0 <3.0.0",
+                                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
+                                }
+                            }
+                        },
+                        "dateformat": {
+                            "version": "1.0.11",
+                            "from": "dateformat@>=1.0.11 <2.0.0",
+                            "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-1.0.11.tgz",
+                            "dependencies": {
+                                "get-stdin": {
+                                    "version": "4.0.1",
+                                    "from": "get-stdin@*",
+                                    "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz"
+                                },
+                                "meow": {
+                                    "version": "3.3.0",
+                                    "from": "meow@*",
+                                    "resolved": "https://registry.npmjs.org/meow/-/meow-3.3.0.tgz",
+                                    "dependencies": {
+                                        "camelcase-keys": {
+                                            "version": "1.0.0",
+                                            "from": "camelcase-keys@>=1.0.0 <2.0.0",
+                                            "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-1.0.0.tgz",
+                                            "dependencies": {
+                                                "camelcase": {
+                                                    "version": "1.1.0",
+                                                    "from": "camelcase@>=1.0.1 <2.0.0",
+                                                    "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.1.0.tgz"
+                                                },
+                                                "map-obj": {
+                                                    "version": "1.0.1",
+                                                    "from": "map-obj@>=1.0.0 <2.0.0",
+                                                    "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz"
+                                                }
+                                            }
+                                        },
+                                        "indent-string": {
+                                            "version": "1.2.1",
+                                            "from": "indent-string@>=1.1.0 <2.0.0",
+                                            "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-1.2.1.tgz",
+                                            "dependencies": {
+                                                "repeating": {
+                                                    "version": "1.1.3",
+                                                    "from": "repeating@>=1.1.0 <2.0.0",
+                                                    "resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
+                                                    "dependencies": {
+                                                        "is-finite": {
+                                                            "version": "1.0.1",
+                                                            "from": "is-finite@>=1.0.0 <2.0.0",
+                                                            "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
+                                                            "dependencies": {
+                                                                "number-is-nan": {
+                                                                    "version": "1.0.0",
+                                                                    "from": "number-is-nan@>=1.0.0 <2.0.0",
+                                                                    "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
+                                                                }
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "lodash._reescape": {
+                            "version": "3.0.0",
+                            "from": "lodash._reescape@>=3.0.0 <4.0.0",
+                            "resolved": "https://registry.npmjs.org/lodash._reescape/-/lodash._reescape-3.0.0.tgz"
+                        },
+                        "lodash._reevaluate": {
+                            "version": "3.0.0",
+                            "from": "lodash._reevaluate@>=3.0.0 <4.0.0",
+                            "resolved": "https://registry.npmjs.org/lodash._reevaluate/-/lodash._reevaluate-3.0.0.tgz"
+                        },
+                        "lodash._reinterpolate": {
+                            "version": "3.0.0",
+                            "from": "lodash._reinterpolate@>=3.0.0 <4.0.0",
+                            "resolved": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz"
+                        },
+                        "lodash.template": {
+                            "version": "3.6.2",
+                            "from": "lodash.template@>=3.0.0 <4.0.0",
+                            "resolved": "https://registry.npmjs.org/lodash.template/-/lodash.template-3.6.2.tgz",
+                            "dependencies": {
+                                "lodash._basecopy": {
+                                    "version": "3.0.1",
+                                    "from": "lodash._basecopy@>=3.0.0 <4.0.0",
+                                    "resolved": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz"
+                                },
+                                "lodash._basetostring": {
+                                    "version": "3.0.1",
+                                    "from": "lodash._basetostring@>=3.0.0 <4.0.0",
+                                    "resolved": "https://registry.npmjs.org/lodash._basetostring/-/lodash._basetostring-3.0.1.tgz"
+                                },
+                                "lodash._basevalues": {
+                                    "version": "3.0.0",
+                                    "from": "lodash._basevalues@>=3.0.0 <4.0.0",
+                                    "resolved": "https://registry.npmjs.org/lodash._basevalues/-/lodash._basevalues-3.0.0.tgz"
+                                },
+                                "lodash._isiterateecall": {
+                                    "version": "3.0.9",
+                                    "from": "lodash._isiterateecall@>=3.0.0 <4.0.0",
+                                    "resolved": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz"
+                                },
+                                "lodash.escape": {
+                                    "version": "3.0.0",
+                                    "from": "lodash.escape@>=3.0.0 <4.0.0",
+                                    "resolved": "https://registry.npmjs.org/lodash.escape/-/lodash.escape-3.0.0.tgz"
+                                },
+                                "lodash.keys": {
+                                    "version": "3.1.2",
+                                    "from": "lodash.keys@>=3.0.0 <4.0.0",
+                                    "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
+                                    "dependencies": {
+                                        "lodash._getnative": {
+                                            "version": "3.9.1",
+                                            "from": "lodash._getnative@>=3.0.0 <4.0.0",
+                                            "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz"
+                                        },
+                                        "lodash.isarguments": {
+                                            "version": "3.0.4",
+                                            "from": "lodash.isarguments@>=3.0.0 <4.0.0",
+                                            "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.0.4.tgz"
+                                        },
+                                        "lodash.isarray": {
+                                            "version": "3.0.4",
+                                            "from": "lodash.isarray@>=3.0.0 <4.0.0",
+                                            "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz"
+                                        }
+                                    }
+                                },
+                                "lodash.restparam": {
+                                    "version": "3.6.1",
+                                    "from": "lodash.restparam@>=3.0.0 <4.0.0",
+                                    "resolved": "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz"
+                                },
+                                "lodash.templatesettings": {
+                                    "version": "3.1.0",
+                                    "from": "lodash.templatesettings@>=3.0.0 <4.0.0",
+                                    "resolved": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-3.1.0.tgz"
+                                }
+                            }
+                        },
+                        "multipipe": {
+                            "version": "0.1.2",
+                            "from": "multipipe@>=0.1.2 <0.2.0",
+                            "resolved": "https://registry.npmjs.org/multipipe/-/multipipe-0.1.2.tgz",
+                            "dependencies": {
+                                "duplexer2": {
+                                    "version": "0.0.2",
+                                    "from": "duplexer2@0.0.2",
+                                    "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.0.2.tgz",
+                                    "dependencies": {
+                                        "readable-stream": {
+                                            "version": "1.1.13",
+                                            "from": "readable-stream@>=1.1.9 <1.2.0",
+                                            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
+                                            "dependencies": {
+                                                "core-util-is": {
+                                                    "version": "1.0.1",
+                                                    "from": "core-util-is@>=1.0.0 <1.1.0",
+                                                    "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                                                },
+                                                "isarray": {
+                                                    "version": "0.0.1",
+                                                    "from": "isarray@0.0.1",
+                                                    "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                                                },
+                                                "string_decoder": {
+                                                    "version": "0.10.31",
+                                                    "from": "string_decoder@>=0.10.0 <0.11.0",
+                                                    "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                                                },
+                                                "inherits": {
+                                                    "version": "2.0.1",
+                                                    "from": "inherits@>=2.0.1 <2.1.0",
+                                                    "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "object-assign": {
+                            "version": "3.0.0",
+                            "from": "object-assign@>=3.0.0 <4.0.0",
+                            "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz"
+                        },
+                        "replace-ext": {
+                            "version": "0.0.1",
+                            "from": "replace-ext@0.0.1",
+                            "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-0.0.1.tgz"
+                        },
+                        "through2": {
+                            "version": "2.0.0",
+                            "from": "through2@>=2.0.0 <3.0.0",
+                            "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.0.tgz",
+                            "dependencies": {
+                                "readable-stream": {
+                                    "version": "2.0.1",
+                                    "from": "readable-stream@>=2.0.0 <2.1.0",
+                                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.1.tgz",
+                                    "dependencies": {
+                                        "core-util-is": {
+                                            "version": "1.0.1",
+                                            "from": "core-util-is@>=1.0.0 <1.1.0",
+                                            "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                                        },
+                                        "inherits": {
+                                            "version": "2.0.1",
+                                            "from": "inherits@>=2.0.1 <2.1.0",
+                                            "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                                        },
+                                        "isarray": {
+                                            "version": "0.0.1",
+                                            "from": "isarray@0.0.1",
+                                            "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                                        },
+                                        "process-nextick-args": {
+                                            "version": "1.0.1",
+                                            "from": "process-nextick-args@>=1.0.0 <1.1.0",
+                                            "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.1.tgz"
+                                        },
+                                        "string_decoder": {
+                                            "version": "0.10.31",
+                                            "from": "string_decoder@>=0.10.0 <0.11.0",
+                                            "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                                        },
+                                        "util-deprecate": {
+                                            "version": "1.0.1",
+                                            "from": "util-deprecate@>=1.0.1 <1.1.0",
+                                            "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.1.tgz"
+                                        }
+                                    }
+                                },
+                                "xtend": {
+                                    "version": "4.0.0",
+                                    "from": "xtend@>=4.0.0 <4.1.0",
+                                    "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz"
+                                }
+                            }
+                        },
+                        "vinyl": {
+                            "version": "0.5.0",
+                            "from": "vinyl@>=0.5.0 <0.6.0",
+                            "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.5.0.tgz",
+                            "dependencies": {
+                                "clone": {
+                                    "version": "1.0.2",
+                                    "from": "clone@>=1.0.0 <2.0.0",
+                                    "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.2.tgz"
+                                },
+                                "clone-stats": {
+                                    "version": "0.0.1",
+                                    "from": "clone-stats@>=0.0.1 <0.0.2",
+                                    "resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz"
+                                }
+                            }
+                        }
+                    }
+                },
+                "interpret": {
+                    "version": "0.3.10",
+                    "from": "interpret@>=0.3.2 <0.4.0",
+                    "resolved": "https://registry.npmjs.org/interpret/-/interpret-0.3.10.tgz"
+                },
+                "liftoff": {
+                    "version": "2.1.0",
+                    "from": "liftoff@>=2.0.1 <3.0.0",
+                    "resolved": "https://registry.npmjs.org/liftoff/-/liftoff-2.1.0.tgz",
+                    "dependencies": {
+                        "extend": {
+                            "version": "2.0.1",
+                            "from": "extend@>=2.0.1 <3.0.0",
+                            "resolved": "https://registry.npmjs.org/extend/-/extend-2.0.1.tgz"
+                        },
+                        "findup-sync": {
+                            "version": "0.2.1",
+                            "from": "findup-sync@>=0.2.1 <0.3.0",
+                            "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-0.2.1.tgz",
+                            "dependencies": {
+                                "glob": {
+                                    "version": "4.3.5",
+                                    "from": "glob@>=4.3.0 <4.4.0",
+                                    "resolved": "https://registry.npmjs.org/glob/-/glob-4.3.5.tgz",
+                                    "dependencies": {
+                                        "inflight": {
+                                            "version": "1.0.4",
+                                            "from": "inflight@>=1.0.4 <2.0.0",
+                                            "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
+                                            "dependencies": {
+                                                "wrappy": {
+                                                    "version": "1.0.1",
+                                                    "from": "wrappy@>=1.0.0 <2.0.0",
+                                                    "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                                                }
+                                            }
+                                        },
+                                        "inherits": {
+                                            "version": "2.0.1",
+                                            "from": "inherits@>=2.0.1 <2.1.0",
+                                            "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                                        },
+                                        "minimatch": {
+                                            "version": "2.0.8",
+                                            "from": "minimatch@>=2.0.1 <3.0.0",
+                                            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.8.tgz",
+                                            "dependencies": {
+                                                "brace-expansion": {
+                                                    "version": "1.1.0",
+                                                    "from": "brace-expansion@>=1.0.0 <2.0.0",
+                                                    "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.0.tgz",
+                                                    "dependencies": {
+                                                        "balanced-match": {
+                                                            "version": "0.2.0",
+                                                            "from": "balanced-match@>=0.2.0 <0.3.0",
+                                                            "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz"
+                                                        },
+                                                        "concat-map": {
+                                                            "version": "0.0.1",
+                                                            "from": "concat-map@0.0.1",
+                                                            "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        },
+                                        "once": {
+                                            "version": "1.3.2",
+                                            "from": "once@>=1.3.0 <2.0.0",
+                                            "resolved": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
+                                            "dependencies": {
+                                                "wrappy": {
+                                                    "version": "1.0.1",
+                                                    "from": "wrappy@>=1.0.0 <2.0.0",
+                                                    "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "flagged-respawn": {
+                            "version": "0.3.1",
+                            "from": "flagged-respawn@>=0.3.1 <0.4.0",
+                            "resolved": "https://registry.npmjs.org/flagged-respawn/-/flagged-respawn-0.3.1.tgz"
+                        },
+                        "rechoir": {
+                            "version": "0.6.1",
+                            "from": "rechoir@>=0.6.0 <0.7.0",
+                            "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.1.tgz"
+                        },
+                        "resolve": {
+                            "version": "1.1.6",
+                            "from": "resolve@>=1.1.6 <2.0.0",
+                            "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.6.tgz"
+                        }
+                    }
+                },
+                "minimist": {
+                    "version": "1.1.1",
+                    "from": "minimist@>=1.1.0 <2.0.0",
+                    "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.1.1.tgz"
+                },
+                "orchestrator": {
+                    "version": "0.3.7",
+                    "from": "orchestrator@>=0.3.0 <0.4.0",
+                    "resolved": "https://registry.npmjs.org/orchestrator/-/orchestrator-0.3.7.tgz",
+                    "dependencies": {
+                        "end-of-stream": {
+                            "version": "0.1.5",
+                            "from": "end-of-stream@>=0.1.5 <0.2.0",
+                            "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-0.1.5.tgz",
+                            "dependencies": {
+                                "once": {
+                                    "version": "1.3.2",
+                                    "from": "once@>=1.3.0 <1.4.0",
+                                    "resolved": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
+                                    "dependencies": {
+                                        "wrappy": {
+                                            "version": "1.0.1",
+                                            "from": "wrappy@>=1.0.0 <2.0.0",
+                                            "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "sequencify": {
+                            "version": "0.0.7",
+                            "from": "sequencify@>=0.0.7 <0.1.0",
+                            "resolved": "https://registry.npmjs.org/sequencify/-/sequencify-0.0.7.tgz"
+                        },
+                        "stream-consume": {
+                            "version": "0.1.0",
+                            "from": "stream-consume@>=0.1.0 <0.2.0",
+                            "resolved": "https://registry.npmjs.org/stream-consume/-/stream-consume-0.1.0.tgz"
+                        }
+                    }
+                },
+                "pretty-hrtime": {
+                    "version": "0.2.2",
+                    "from": "pretty-hrtime@>=0.2.0 <0.3.0",
+                    "resolved": "https://registry.npmjs.org/pretty-hrtime/-/pretty-hrtime-0.2.2.tgz"
+                },
+                "semver": {
+                    "version": "4.3.6",
+                    "from": "semver@>=4.1.0 <5.0.0",
+                    "resolved": "https://registry.npmjs.org/semver/-/semver-4.3.6.tgz"
+                },
+                "tildify": {
+                    "version": "1.1.0",
+                    "from": "tildify@>=1.0.0 <2.0.0",
+                    "resolved": "https://registry.npmjs.org/tildify/-/tildify-1.1.0.tgz",
+                    "dependencies": {
+                        "os-homedir": {
+                            "version": "1.0.0",
+                            "from": "os-homedir@>=1.0.0 <2.0.0",
+                            "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.0.tgz"
+                        }
+                    }
+                },
+                "v8flags": {
+                    "version": "2.0.9",
+                    "from": "v8flags@>=2.0.2 <3.0.0",
+                    "resolved": "https://registry.npmjs.org/v8flags/-/v8flags-2.0.9.tgz",
+                    "dependencies": {
+                        "user-home": {
+                            "version": "1.1.1",
+                            "from": "user-home@>=1.1.1 <2.0.0",
+                            "resolved": "https://registry.npmjs.org/user-home/-/user-home-1.1.1.tgz"
+                        }
+                    }
+                },
+                "vinyl-fs": {
+                    "version": "0.3.13",
+                    "from": "vinyl-fs@>=0.3.0 <0.4.0",
+                    "resolved": "https://registry.npmjs.org/vinyl-fs/-/vinyl-fs-0.3.13.tgz",
+                    "dependencies": {
+                        "defaults": {
+                            "version": "1.0.2",
+                            "from": "defaults@>=1.0.0 <2.0.0",
+                            "resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.2.tgz",
+                            "dependencies": {
+                                "clone": {
+                                    "version": "0.1.19",
+                                    "from": "clone@>=0.1.5 <0.2.0",
+                                    "resolved": "https://registry.npmjs.org/clone/-/clone-0.1.19.tgz"
+                                }
+                            }
+                        },
+                        "glob-stream": {
+                            "version": "3.1.18",
+                            "from": "glob-stream@>=3.1.5 <4.0.0",
+                            "resolved": "https://registry.npmjs.org/glob-stream/-/glob-stream-3.1.18.tgz",
+                            "dependencies": {
+                                "glob": {
+                                    "version": "4.5.3",
+                                    "from": "glob@>=4.3.1 <5.0.0",
+                                    "resolved": "https://registry.npmjs.org/glob/-/glob-4.5.3.tgz",
+                                    "dependencies": {
+                                        "inflight": {
+                                            "version": "1.0.4",
+                                            "from": "inflight@>=1.0.4 <2.0.0",
+                                            "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
+                                            "dependencies": {
+                                                "wrappy": {
+                                                    "version": "1.0.1",
+                                                    "from": "wrappy@>=1.0.0 <2.0.0",
+                                                    "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                                                }
+                                            }
+                                        },
+                                        "inherits": {
+                                            "version": "2.0.1",
+                                            "from": "inherits@>=2.0.1 <2.1.0",
+                                            "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                                        },
+                                        "once": {
+                                            "version": "1.3.2",
+                                            "from": "once@>=1.3.0 <2.0.0",
+                                            "resolved": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
+                                            "dependencies": {
+                                                "wrappy": {
+                                                    "version": "1.0.1",
+                                                    "from": "wrappy@>=1.0.0 <2.0.0",
+                                                    "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                                                }
+                                            }
+                                        }
+                                    }
+                                },
+                                "minimatch": {
+                                    "version": "2.0.8",
+                                    "from": "minimatch@>=2.0.1 <3.0.0",
+                                    "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.8.tgz",
+                                    "dependencies": {
+                                        "brace-expansion": {
+                                            "version": "1.1.0",
+                                            "from": "brace-expansion@>=1.0.0 <2.0.0",
+                                            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.0.tgz",
+                                            "dependencies": {
+                                                "balanced-match": {
+                                                    "version": "0.2.0",
+                                                    "from": "balanced-match@>=0.2.0 <0.3.0",
+                                                    "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz"
+                                                },
+                                                "concat-map": {
+                                                    "version": "0.0.1",
+                                                    "from": "concat-map@0.0.1",
+                                                    "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+                                                }
+                                            }
+                                        }
+                                    }
+                                },
+                                "ordered-read-streams": {
+                                    "version": "0.1.0",
+                                    "from": "ordered-read-streams@>=0.1.0 <0.2.0",
+                                    "resolved": "https://registry.npmjs.org/ordered-read-streams/-/ordered-read-streams-0.1.0.tgz"
+                                },
+                                "glob2base": {
+                                    "version": "0.0.12",
+                                    "from": "glob2base@>=0.0.12 <0.0.13",
+                                    "resolved": "https://registry.npmjs.org/glob2base/-/glob2base-0.0.12.tgz",
+                                    "dependencies": {
+                                        "find-index": {
+                                            "version": "0.1.1",
+                                            "from": "find-index@>=0.1.1 <0.2.0",
+                                            "resolved": "https://registry.npmjs.org/find-index/-/find-index-0.1.1.tgz"
+                                        }
+                                    }
+                                },
+                                "unique-stream": {
+                                    "version": "1.0.0",
+                                    "from": "unique-stream@>=1.0.0 <2.0.0",
+                                    "resolved": "https://registry.npmjs.org/unique-stream/-/unique-stream-1.0.0.tgz"
+                                }
+                            }
+                        },
+                        "glob-watcher": {
+                            "version": "0.0.6",
+                            "from": "glob-watcher@>=0.0.6 <0.0.7",
+                            "resolved": "https://registry.npmjs.org/glob-watcher/-/glob-watcher-0.0.6.tgz",
+                            "dependencies": {
+                                "gaze": {
+                                    "version": "0.5.1",
+                                    "from": "gaze@>=0.5.1 <0.6.0",
+                                    "resolved": "https://registry.npmjs.org/gaze/-/gaze-0.5.1.tgz",
+                                    "dependencies": {
+                                        "globule": {
+                                            "version": "0.1.0",
+                                            "from": "globule@>=0.1.0 <0.2.0",
+                                            "resolved": "https://registry.npmjs.org/globule/-/globule-0.1.0.tgz",
+                                            "dependencies": {
+                                                "lodash": {
+                                                    "version": "1.0.2",
+                                                    "from": "lodash@>=1.0.1 <1.1.0",
+                                                    "resolved": "https://registry.npmjs.org/lodash/-/lodash-1.0.2.tgz"
+                                                },
+                                                "glob": {
+                                                    "version": "3.1.21",
+                                                    "from": "glob@>=3.1.21 <3.2.0",
+                                                    "resolved": "https://registry.npmjs.org/glob/-/glob-3.1.21.tgz",
+                                                    "dependencies": {
+                                                        "graceful-fs": {
+                                                            "version": "1.2.3",
+                                                            "from": "graceful-fs@>=1.2.0 <1.3.0",
+                                                            "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-1.2.3.tgz"
+                                                        },
+                                                        "inherits": {
+                                                            "version": "1.0.0",
+                                                            "from": "inherits@>=1.0.0 <2.0.0",
+                                                            "resolved": "https://registry.npmjs.org/inherits/-/inherits-1.0.0.tgz"
+                                                        }
+                                                    }
+                                                },
+                                                "minimatch": {
+                                                    "version": "0.2.14",
+                                                    "from": "minimatch@>=0.2.11 <0.3.0",
+                                                    "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
+                                                    "dependencies": {
+                                                        "lru-cache": {
+                                                            "version": "2.6.5",
+                                                            "from": "lru-cache@>=2.0.0 <3.0.0",
+                                                            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.5.tgz"
+                                                        },
+                                                        "sigmund": {
+                                                            "version": "1.0.1",
+                                                            "from": "sigmund@>=1.0.0 <1.1.0",
+                                                            "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz"
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "graceful-fs": {
+                            "version": "3.0.8",
+                            "from": "graceful-fs@>=3.0.0 <4.0.0",
+                            "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.8.tgz"
+                        },
+                        "mkdirp": {
+                            "version": "0.5.1",
+                            "from": "mkdirp@>=0.5.0 <0.6.0",
+                            "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+                            "dependencies": {
+                                "minimist": {
+                                    "version": "0.0.8",
+                                    "from": "minimist@0.0.8",
+                                    "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
+                                }
+                            }
+                        },
+                        "strip-bom": {
+                            "version": "1.0.0",
+                            "from": "strip-bom@>=1.0.0 <2.0.0",
+                            "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-1.0.0.tgz",
+                            "dependencies": {
+                                "first-chunk-stream": {
+                                    "version": "1.0.0",
+                                    "from": "first-chunk-stream@>=1.0.0 <2.0.0",
+                                    "resolved": "https://registry.npmjs.org/first-chunk-stream/-/first-chunk-stream-1.0.0.tgz"
+                                },
+                                "is-utf8": {
+                                    "version": "0.2.0",
+                                    "from": "is-utf8@>=0.2.0 <0.3.0",
+                                    "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.0.tgz"
+                                }
+                            }
+                        },
+                        "through2": {
+                            "version": "0.6.5",
+                            "from": "through2@>=0.6.1 <0.7.0",
+                            "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
+                            "dependencies": {
+                                "readable-stream": {
+                                    "version": "1.0.33",
+                                    "from": "readable-stream@>=1.0.33-1 <1.1.0-0",
+                                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
+                                    "dependencies": {
+                                        "core-util-is": {
+                                            "version": "1.0.1",
+                                            "from": "core-util-is@>=1.0.0 <1.1.0",
+                                            "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                                        },
+                                        "isarray": {
+                                            "version": "0.0.1",
+                                            "from": "isarray@0.0.1",
+                                            "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                                        },
+                                        "string_decoder": {
+                                            "version": "0.10.31",
+                                            "from": "string_decoder@>=0.10.0 <0.11.0",
+                                            "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                                        },
+                                        "inherits": {
+                                            "version": "2.0.1",
+                                            "from": "inherits@>=2.0.1 <2.1.0",
+                                            "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                                        }
+                                    }
+                                },
+                                "xtend": {
+                                    "version": "4.0.0",
+                                    "from": "xtend@>=4.0.0 <4.1.0-0",
+                                    "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz"
+                                }
+                            }
+                        },
+                        "vinyl": {
+                            "version": "0.4.6",
+                            "from": "vinyl@>=0.4.0 <0.5.0",
+                            "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.4.6.tgz",
+                            "dependencies": {
+                                "clone": {
+                                    "version": "0.2.0",
+                                    "from": "clone@>=0.2.0 <0.3.0",
+                                    "resolved": "https://registry.npmjs.org/clone/-/clone-0.2.0.tgz"
+                                },
+                                "clone-stats": {
+                                    "version": "0.0.1",
+                                    "from": "clone-stats@>=0.0.1 <0.0.2",
+                                    "resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "gulp-file-include": {
+            "version": "0.11.0",
+            "from": "gulp-file-include@0.11.0",
+            "resolved": "https://registry.npmjs.org/gulp-file-include/-/gulp-file-include-0.11.0.tgz",
+            "dependencies": {
+                "concat-stream": {
+                    "version": "1.5.0",
+                    "from": "concat-stream@>=1.4.7 <2.0.0",
+                    "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.5.0.tgz",
+                    "dependencies": {
+                        "inherits": {
+                            "version": "2.0.1",
+                            "from": "inherits@>=2.0.1 <2.1.0",
+                            "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                        },
+                        "typedarray": {
+                            "version": "0.0.6",
+                            "from": "typedarray@>=0.0.5 <0.1.0",
+                            "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz"
+                        },
+                        "readable-stream": {
+                            "version": "2.0.1",
+                            "from": "readable-stream@>=2.0.0 <2.1.0",
+                            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.1.tgz",
+                            "dependencies": {
+                                "core-util-is": {
+                                    "version": "1.0.1",
+                                    "from": "core-util-is@>=1.0.0 <1.1.0",
+                                    "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                                },
+                                "isarray": {
+                                    "version": "0.0.1",
+                                    "from": "isarray@0.0.1",
+                                    "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                                },
+                                "process-nextick-args": {
+                                    "version": "1.0.1",
+                                    "from": "process-nextick-args@>=1.0.0 <1.1.0",
+                                    "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.1.tgz"
+                                },
+                                "string_decoder": {
+                                    "version": "0.10.31",
+                                    "from": "string_decoder@>=0.10.0 <0.11.0",
+                                    "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                                },
+                                "util-deprecate": {
+                                    "version": "1.0.1",
+                                    "from": "util-deprecate@>=1.0.1 <1.1.0",
+                                    "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.1.tgz"
+                                }
+                            }
+                        }
+                    }
+                },
+                "flatnest": {
+                    "version": "0.2.2",
+                    "from": "flatnest@>=0.2.2 <0.3.0",
+                    "resolved": "https://registry.npmjs.org/flatnest/-/flatnest-0.2.2.tgz"
+                },
+                "gulp-util": {
+                    "version": "3.0.6",
+                    "from": "gulp-util@>=3.0.4 <4.0.0",
+                    "resolved": "https://registry.npmjs.org/gulp-util/-/gulp-util-3.0.6.tgz",
+                    "dependencies": {
+                        "array-differ": {
+                            "version": "1.0.0",
+                            "from": "array-differ@>=1.0.0 <2.0.0",
+                            "resolved": "https://registry.npmjs.org/array-differ/-/array-differ-1.0.0.tgz"
+                        },
+                        "array-uniq": {
+                            "version": "1.0.2",
+                            "from": "array-uniq@>=1.0.2 <2.0.0",
+                            "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.2.tgz"
+                        },
+                        "beeper": {
+                            "version": "1.1.0",
+                            "from": "beeper@>=1.0.0 <2.0.0",
+                            "resolved": "https://registry.npmjs.org/beeper/-/beeper-1.1.0.tgz"
+                        },
+                        "chalk": {
+                            "version": "1.1.0",
+                            "from": "chalk@>=1.0.0 <2.0.0",
+                            "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.0.tgz",
+                            "dependencies": {
+                                "ansi-styles": {
+                                    "version": "2.1.0",
+                                    "from": "ansi-styles@>=2.1.0 <3.0.0",
+                                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz"
+                                },
+                                "escape-string-regexp": {
+                                    "version": "1.0.3",
+                                    "from": "escape-string-regexp@>=1.0.2 <2.0.0",
+                                    "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
+                                },
+                                "has-ansi": {
+                                    "version": "2.0.0",
+                                    "from": "has-ansi@>=2.0.0 <3.0.0",
+                                    "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+                                    "dependencies": {
+                                        "ansi-regex": {
+                                            "version": "2.0.0",
+                                            "from": "ansi-regex@>=2.0.0 <3.0.0",
+                                            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
+                                        }
+                                    }
+                                },
+                                "strip-ansi": {
+                                    "version": "3.0.0",
+                                    "from": "strip-ansi@>=3.0.0 <4.0.0",
+                                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
+                                    "dependencies": {
+                                        "ansi-regex": {
+                                            "version": "2.0.0",
+                                            "from": "ansi-regex@>=2.0.0 <3.0.0",
+                                            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
+                                        }
+                                    }
+                                },
+                                "supports-color": {
+                                    "version": "2.0.0",
+                                    "from": "supports-color@>=2.0.0 <3.0.0",
+                                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
+                                }
+                            }
+                        },
+                        "dateformat": {
+                            "version": "1.0.11",
+                            "from": "dateformat@>=1.0.11 <2.0.0",
+                            "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-1.0.11.tgz",
+                            "dependencies": {
+                                "get-stdin": {
+                                    "version": "4.0.1",
+                                    "from": "get-stdin@*",
+                                    "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz"
+                                },
+                                "meow": {
+                                    "version": "3.3.0",
+                                    "from": "meow@*",
+                                    "resolved": "https://registry.npmjs.org/meow/-/meow-3.3.0.tgz",
+                                    "dependencies": {
+                                        "camelcase-keys": {
+                                            "version": "1.0.0",
+                                            "from": "camelcase-keys@>=1.0.0 <2.0.0",
+                                            "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-1.0.0.tgz",
+                                            "dependencies": {
+                                                "camelcase": {
+                                                    "version": "1.1.0",
+                                                    "from": "camelcase@>=1.0.1 <2.0.0",
+                                                    "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.1.0.tgz"
+                                                },
+                                                "map-obj": {
+                                                    "version": "1.0.1",
+                                                    "from": "map-obj@>=1.0.0 <2.0.0",
+                                                    "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz"
+                                                }
+                                            }
+                                        },
+                                        "indent-string": {
+                                            "version": "1.2.1",
+                                            "from": "indent-string@>=1.1.0 <2.0.0",
+                                            "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-1.2.1.tgz",
+                                            "dependencies": {
+                                                "repeating": {
+                                                    "version": "1.1.3",
+                                                    "from": "repeating@>=1.1.0 <2.0.0",
+                                                    "resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
+                                                    "dependencies": {
+                                                        "is-finite": {
+                                                            "version": "1.0.1",
+                                                            "from": "is-finite@>=1.0.0 <2.0.0",
+                                                            "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
+                                                            "dependencies": {
+                                                                "number-is-nan": {
+                                                                    "version": "1.0.0",
+                                                                    "from": "number-is-nan@>=1.0.0 <2.0.0",
+                                                                    "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
+                                                                }
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "lodash._reescape": {
+                            "version": "3.0.0",
+                            "from": "lodash._reescape@>=3.0.0 <4.0.0",
+                            "resolved": "https://registry.npmjs.org/lodash._reescape/-/lodash._reescape-3.0.0.tgz"
+                        },
+                        "lodash._reevaluate": {
+                            "version": "3.0.0",
+                            "from": "lodash._reevaluate@>=3.0.0 <4.0.0",
+                            "resolved": "https://registry.npmjs.org/lodash._reevaluate/-/lodash._reevaluate-3.0.0.tgz"
+                        },
+                        "lodash._reinterpolate": {
+                            "version": "3.0.0",
+                            "from": "lodash._reinterpolate@>=3.0.0 <4.0.0",
+                            "resolved": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz"
+                        },
+                        "lodash.template": {
+                            "version": "3.6.2",
+                            "from": "lodash.template@>=3.0.0 <4.0.0",
+                            "resolved": "https://registry.npmjs.org/lodash.template/-/lodash.template-3.6.2.tgz",
+                            "dependencies": {
+                                "lodash._basecopy": {
+                                    "version": "3.0.1",
+                                    "from": "lodash._basecopy@>=3.0.0 <4.0.0",
+                                    "resolved": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz"
+                                },
+                                "lodash._basetostring": {
+                                    "version": "3.0.1",
+                                    "from": "lodash._basetostring@>=3.0.0 <4.0.0",
+                                    "resolved": "https://registry.npmjs.org/lodash._basetostring/-/lodash._basetostring-3.0.1.tgz"
+                                },
+                                "lodash._basevalues": {
+                                    "version": "3.0.0",
+                                    "from": "lodash._basevalues@>=3.0.0 <4.0.0",
+                                    "resolved": "https://registry.npmjs.org/lodash._basevalues/-/lodash._basevalues-3.0.0.tgz"
+                                },
+                                "lodash._isiterateecall": {
+                                    "version": "3.0.9",
+                                    "from": "lodash._isiterateecall@>=3.0.0 <4.0.0",
+                                    "resolved": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz"
+                                },
+                                "lodash.escape": {
+                                    "version": "3.0.0",
+                                    "from": "lodash.escape@>=3.0.0 <4.0.0",
+                                    "resolved": "https://registry.npmjs.org/lodash.escape/-/lodash.escape-3.0.0.tgz"
+                                },
+                                "lodash.keys": {
+                                    "version": "3.1.2",
+                                    "from": "lodash.keys@>=3.0.0 <4.0.0",
+                                    "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
+                                    "dependencies": {
+                                        "lodash._getnative": {
+                                            "version": "3.9.1",
+                                            "from": "lodash._getnative@>=3.0.0 <4.0.0",
+                                            "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz"
+                                        },
+                                        "lodash.isarguments": {
+                                            "version": "3.0.4",
+                                            "from": "lodash.isarguments@>=3.0.0 <4.0.0",
+                                            "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.0.4.tgz"
+                                        },
+                                        "lodash.isarray": {
+                                            "version": "3.0.4",
+                                            "from": "lodash.isarray@>=3.0.0 <4.0.0",
+                                            "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz"
+                                        }
+                                    }
+                                },
+                                "lodash.restparam": {
+                                    "version": "3.6.1",
+                                    "from": "lodash.restparam@>=3.0.0 <4.0.0",
+                                    "resolved": "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz"
+                                },
+                                "lodash.templatesettings": {
+                                    "version": "3.1.0",
+                                    "from": "lodash.templatesettings@>=3.0.0 <4.0.0",
+                                    "resolved": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-3.1.0.tgz"
+                                }
+                            }
+                        },
+                        "minimist": {
+                            "version": "1.1.1",
+                            "from": "minimist@>=1.1.0 <2.0.0",
+                            "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.1.1.tgz"
+                        },
+                        "multipipe": {
+                            "version": "0.1.2",
+                            "from": "multipipe@>=0.1.2 <0.2.0",
+                            "resolved": "https://registry.npmjs.org/multipipe/-/multipipe-0.1.2.tgz",
+                            "dependencies": {
+                                "duplexer2": {
+                                    "version": "0.0.2",
+                                    "from": "duplexer2@0.0.2",
+                                    "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.0.2.tgz",
+                                    "dependencies": {
+                                        "readable-stream": {
+                                            "version": "1.1.13",
+                                            "from": "readable-stream@>=1.1.9 <1.2.0",
+                                            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
+                                            "dependencies": {
+                                                "core-util-is": {
+                                                    "version": "1.0.1",
+                                                    "from": "core-util-is@>=1.0.0 <1.1.0",
+                                                    "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                                                },
+                                                "isarray": {
+                                                    "version": "0.0.1",
+                                                    "from": "isarray@0.0.1",
+                                                    "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                                                },
+                                                "string_decoder": {
+                                                    "version": "0.10.31",
+                                                    "from": "string_decoder@>=0.10.0 <0.11.0",
+                                                    "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                                                },
+                                                "inherits": {
+                                                    "version": "2.0.1",
+                                                    "from": "inherits@>=2.0.1 <2.1.0",
+                                                    "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "object-assign": {
+                            "version": "3.0.0",
+                            "from": "object-assign@>=3.0.0 <4.0.0",
+                            "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz"
+                        },
+                        "replace-ext": {
+                            "version": "0.0.1",
+                            "from": "replace-ext@0.0.1",
+                            "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-0.0.1.tgz"
+                        },
+                        "vinyl": {
+                            "version": "0.5.0",
+                            "from": "vinyl@>=0.5.0 <0.6.0",
+                            "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.5.0.tgz",
+                            "dependencies": {
+                                "clone": {
+                                    "version": "1.0.2",
+                                    "from": "clone@>=1.0.0 <2.0.0",
+                                    "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.2.tgz"
+                                },
+                                "clone-stats": {
+                                    "version": "0.0.1",
+                                    "from": "clone-stats@>=0.0.1 <0.0.2",
+                                    "resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz"
+                                }
+                            }
+                        }
+                    }
+                },
+                "merge": {
+                    "version": "1.2.0",
+                    "from": "merge@>=1.2.0 <2.0.0",
+                    "resolved": "https://registry.npmjs.org/merge/-/merge-1.2.0.tgz"
+                },
+                "through2": {
+                    "version": "2.0.0",
+                    "from": "through2@>=2.0.0 <3.0.0",
+                    "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.0.tgz",
+                    "dependencies": {
+                        "readable-stream": {
+                            "version": "2.0.1",
+                            "from": "readable-stream@>=2.0.0 <2.1.0",
+                            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.1.tgz",
+                            "dependencies": {
+                                "core-util-is": {
+                                    "version": "1.0.1",
+                                    "from": "core-util-is@>=1.0.0 <1.1.0",
+                                    "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                                },
+                                "inherits": {
+                                    "version": "2.0.1",
+                                    "from": "inherits@>=2.0.1 <2.1.0",
+                                    "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                                },
+                                "isarray": {
+                                    "version": "0.0.1",
+                                    "from": "isarray@0.0.1",
+                                    "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                                },
+                                "process-nextick-args": {
+                                    "version": "1.0.1",
+                                    "from": "process-nextick-args@>=1.0.0 <1.1.0",
+                                    "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.1.tgz"
+                                },
+                                "string_decoder": {
+                                    "version": "0.10.31",
+                                    "from": "string_decoder@>=0.10.0 <0.11.0",
+                                    "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                                },
+                                "util-deprecate": {
+                                    "version": "1.0.1",
+                                    "from": "util-deprecate@>=1.0.1 <1.1.0",
+                                    "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.1.tgz"
+                                }
+                            }
+                        },
+                        "xtend": {
+                            "version": "4.0.0",
+                            "from": "xtend@>=4.0.0 <4.1.0",
+                            "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz"
+                        }
+                    }
+                }
+            }
+        },
+        "gulp-marked": {
+            "version": "1.0.0",
+            "from": "gulp-marked@1.0.0",
+            "resolved": "https://registry.npmjs.org/gulp-marked/-/gulp-marked-1.0.0.tgz",
+            "dependencies": {
+                "marked": {
+                    "version": "0.3.3",
+                    "from": "marked@>=0.3.2 <0.4.0",
+                    "resolved": "https://registry.npmjs.org/marked/-/marked-0.3.3.tgz"
+                },
+                "bufferstreams": {
+                    "version": "0.0.1",
+                    "from": "bufferstreams@0.0.1",
+                    "resolved": "https://registry.npmjs.org/bufferstreams/-/bufferstreams-0.0.1.tgz"
+                },
+                "gulp-util": {
+                    "version": "2.2.20",
+                    "from": "gulp-util@>=2.2.9 <2.3.0",
+                    "resolved": "https://registry.npmjs.org/gulp-util/-/gulp-util-2.2.20.tgz",
+                    "dependencies": {
+                        "chalk": {
+                            "version": "0.5.1",
+                            "from": "chalk@>=0.5.0 <0.6.0",
+                            "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.5.1.tgz",
+                            "dependencies": {
+                                "ansi-styles": {
+                                    "version": "1.1.0",
+                                    "from": "ansi-styles@>=1.1.0 <2.0.0",
+                                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.1.0.tgz"
+                                },
+                                "escape-string-regexp": {
+                                    "version": "1.0.3",
+                                    "from": "escape-string-regexp@>=1.0.0 <2.0.0",
+                                    "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
+                                },
+                                "has-ansi": {
+                                    "version": "0.1.0",
+                                    "from": "has-ansi@>=0.1.0 <0.2.0",
+                                    "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-0.1.0.tgz",
+                                    "dependencies": {
+                                        "ansi-regex": {
+                                            "version": "0.2.1",
+                                            "from": "ansi-regex@>=0.2.1 <0.3.0",
+                                            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
+                                        }
+                                    }
+                                },
+                                "strip-ansi": {
+                                    "version": "0.3.0",
+                                    "from": "strip-ansi@>=0.3.0 <0.4.0",
+                                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.3.0.tgz",
+                                    "dependencies": {
+                                        "ansi-regex": {
+                                            "version": "0.2.1",
+                                            "from": "ansi-regex@>=0.2.1 <0.3.0",
+                                            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
+                                        }
+                                    }
+                                },
+                                "supports-color": {
+                                    "version": "0.2.0",
+                                    "from": "supports-color@>=0.2.0 <0.3.0",
+                                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-0.2.0.tgz"
+                                }
+                            }
+                        },
+                        "dateformat": {
+                            "version": "1.0.11",
+                            "from": "dateformat@>=1.0.7-1.2.3 <2.0.0",
+                            "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-1.0.11.tgz",
+                            "dependencies": {
+                                "get-stdin": {
+                                    "version": "4.0.1",
+                                    "from": "get-stdin@*",
+                                    "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz"
+                                },
+                                "meow": {
+                                    "version": "3.3.0",
+                                    "from": "meow@*",
+                                    "resolved": "https://registry.npmjs.org/meow/-/meow-3.3.0.tgz",
+                                    "dependencies": {
+                                        "camelcase-keys": {
+                                            "version": "1.0.0",
+                                            "from": "camelcase-keys@>=1.0.0 <2.0.0",
+                                            "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-1.0.0.tgz",
+                                            "dependencies": {
+                                                "camelcase": {
+                                                    "version": "1.1.0",
+                                                    "from": "camelcase@>=1.0.1 <2.0.0",
+                                                    "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.1.0.tgz"
+                                                },
+                                                "map-obj": {
+                                                    "version": "1.0.1",
+                                                    "from": "map-obj@>=1.0.0 <2.0.0",
+                                                    "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz"
+                                                }
+                                            }
+                                        },
+                                        "indent-string": {
+                                            "version": "1.2.1",
+                                            "from": "indent-string@>=1.1.0 <2.0.0",
+                                            "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-1.2.1.tgz",
+                                            "dependencies": {
+                                                "repeating": {
+                                                    "version": "1.1.3",
+                                                    "from": "repeating@>=1.1.0 <2.0.0",
+                                                    "resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
+                                                    "dependencies": {
+                                                        "is-finite": {
+                                                            "version": "1.0.1",
+                                                            "from": "is-finite@>=1.0.0 <2.0.0",
+                                                            "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
+                                                            "dependencies": {
+                                                                "number-is-nan": {
+                                                                    "version": "1.0.0",
+                                                                    "from": "number-is-nan@>=1.0.0 <2.0.0",
+                                                                    "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
+                                                                }
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        },
+                                        "minimist": {
+                                            "version": "1.1.1",
+                                            "from": "minimist@>=1.1.0 <2.0.0",
+                                            "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.1.1.tgz"
+                                        },
+                                        "object-assign": {
+                                            "version": "3.0.0",
+                                            "from": "object-assign@>=3.0.0 <4.0.0",
+                                            "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz"
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "lodash._reinterpolate": {
+                            "version": "2.4.1",
+                            "from": "lodash._reinterpolate@>=2.4.1 <3.0.0",
+                            "resolved": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-2.4.1.tgz"
+                        },
+                        "lodash.template": {
+                            "version": "2.4.1",
+                            "from": "lodash.template@>=2.4.1 <3.0.0",
+                            "resolved": "https://registry.npmjs.org/lodash.template/-/lodash.template-2.4.1.tgz",
+                            "dependencies": {
+                                "lodash.defaults": {
+                                    "version": "2.4.1",
+                                    "from": "lodash.defaults@>=2.4.1 <2.5.0",
+                                    "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-2.4.1.tgz",
+                                    "dependencies": {
+                                        "lodash._objecttypes": {
+                                            "version": "2.4.1",
+                                            "from": "lodash._objecttypes@>=2.4.1 <2.5.0",
+                                            "resolved": "https://registry.npmjs.org/lodash._objecttypes/-/lodash._objecttypes-2.4.1.tgz"
+                                        }
+                                    }
+                                },
+                                "lodash.escape": {
+                                    "version": "2.4.1",
+                                    "from": "lodash.escape@>=2.4.1 <2.5.0",
+                                    "resolved": "https://registry.npmjs.org/lodash.escape/-/lodash.escape-2.4.1.tgz",
+                                    "dependencies": {
+                                        "lodash._escapehtmlchar": {
+                                            "version": "2.4.1",
+                                            "from": "lodash._escapehtmlchar@>=2.4.1 <2.5.0",
+                                            "resolved": "https://registry.npmjs.org/lodash._escapehtmlchar/-/lodash._escapehtmlchar-2.4.1.tgz",
+                                            "dependencies": {
+                                                "lodash._htmlescapes": {
+                                                    "version": "2.4.1",
+                                                    "from": "lodash._htmlescapes@>=2.4.1 <2.5.0",
+                                                    "resolved": "https://registry.npmjs.org/lodash._htmlescapes/-/lodash._htmlescapes-2.4.1.tgz"
+                                                }
+                                            }
+                                        },
+                                        "lodash._reunescapedhtml": {
+                                            "version": "2.4.1",
+                                            "from": "lodash._reunescapedhtml@>=2.4.1 <2.5.0",
+                                            "resolved": "https://registry.npmjs.org/lodash._reunescapedhtml/-/lodash._reunescapedhtml-2.4.1.tgz",
+                                            "dependencies": {
+                                                "lodash._htmlescapes": {
+                                                    "version": "2.4.1",
+                                                    "from": "lodash._htmlescapes@>=2.4.1 <2.5.0",
+                                                    "resolved": "https://registry.npmjs.org/lodash._htmlescapes/-/lodash._htmlescapes-2.4.1.tgz"
+                                                }
+                                            }
+                                        }
+                                    }
+                                },
+                                "lodash._escapestringchar": {
+                                    "version": "2.4.1",
+                                    "from": "lodash._escapestringchar@>=2.4.1 <2.5.0",
+                                    "resolved": "https://registry.npmjs.org/lodash._escapestringchar/-/lodash._escapestringchar-2.4.1.tgz"
+                                },
+                                "lodash.keys": {
+                                    "version": "2.4.1",
+                                    "from": "lodash.keys@>=2.4.1 <2.5.0",
+                                    "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-2.4.1.tgz",
+                                    "dependencies": {
+                                        "lodash._isnative": {
+                                            "version": "2.4.1",
+                                            "from": "lodash._isnative@>=2.4.1 <2.5.0",
+                                            "resolved": "https://registry.npmjs.org/lodash._isnative/-/lodash._isnative-2.4.1.tgz"
+                                        },
+                                        "lodash.isobject": {
+                                            "version": "2.4.1",
+                                            "from": "lodash.isobject@>=2.4.1 <2.5.0",
+                                            "resolved": "https://registry.npmjs.org/lodash.isobject/-/lodash.isobject-2.4.1.tgz",
+                                            "dependencies": {
+                                                "lodash._objecttypes": {
+                                                    "version": "2.4.1",
+                                                    "from": "lodash._objecttypes@>=2.4.1 <2.5.0",
+                                                    "resolved": "https://registry.npmjs.org/lodash._objecttypes/-/lodash._objecttypes-2.4.1.tgz"
+                                                }
+                                            }
+                                        },
+                                        "lodash._shimkeys": {
+                                            "version": "2.4.1",
+                                            "from": "lodash._shimkeys@>=2.4.1 <2.5.0",
+                                            "resolved": "https://registry.npmjs.org/lodash._shimkeys/-/lodash._shimkeys-2.4.1.tgz",
+                                            "dependencies": {
+                                                "lodash._objecttypes": {
+                                                    "version": "2.4.1",
+                                                    "from": "lodash._objecttypes@>=2.4.1 <2.5.0",
+                                                    "resolved": "https://registry.npmjs.org/lodash._objecttypes/-/lodash._objecttypes-2.4.1.tgz"
+                                                }
+                                            }
+                                        }
+                                    }
+                                },
+                                "lodash.templatesettings": {
+                                    "version": "2.4.1",
+                                    "from": "lodash.templatesettings@>=2.4.1 <2.5.0",
+                                    "resolved": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-2.4.1.tgz"
+                                },
+                                "lodash.values": {
+                                    "version": "2.4.1",
+                                    "from": "lodash.values@>=2.4.1 <2.5.0",
+                                    "resolved": "https://registry.npmjs.org/lodash.values/-/lodash.values-2.4.1.tgz"
+                                }
+                            }
+                        },
+                        "minimist": {
+                            "version": "0.2.0",
+                            "from": "minimist@>=0.2.0 <0.3.0",
+                            "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.2.0.tgz"
+                        },
+                        "multipipe": {
+                            "version": "0.1.2",
+                            "from": "multipipe@>=0.1.0 <0.2.0",
+                            "resolved": "https://registry.npmjs.org/multipipe/-/multipipe-0.1.2.tgz",
+                            "dependencies": {
+                                "duplexer2": {
+                                    "version": "0.0.2",
+                                    "from": "duplexer2@0.0.2",
+                                    "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.0.2.tgz",
+                                    "dependencies": {
+                                        "readable-stream": {
+                                            "version": "1.1.13",
+                                            "from": "readable-stream@>=1.1.9 <1.2.0",
+                                            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
+                                            "dependencies": {
+                                                "core-util-is": {
+                                                    "version": "1.0.1",
+                                                    "from": "core-util-is@>=1.0.0 <1.1.0",
+                                                    "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                                                },
+                                                "isarray": {
+                                                    "version": "0.0.1",
+                                                    "from": "isarray@0.0.1",
+                                                    "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                                                },
+                                                "string_decoder": {
+                                                    "version": "0.10.31",
+                                                    "from": "string_decoder@>=0.10.0 <0.11.0",
+                                                    "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                                                },
+                                                "inherits": {
+                                                    "version": "2.0.1",
+                                                    "from": "inherits@>=2.0.1 <2.1.0",
+                                                    "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "through2": {
+                            "version": "0.5.1",
+                            "from": "through2@>=0.5.0 <0.6.0",
+                            "resolved": "https://registry.npmjs.org/through2/-/through2-0.5.1.tgz",
+                            "dependencies": {
+                                "readable-stream": {
+                                    "version": "1.0.33",
+                                    "from": "readable-stream@>=1.0.17 <1.1.0",
+                                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
+                                    "dependencies": {
+                                        "core-util-is": {
+                                            "version": "1.0.1",
+                                            "from": "core-util-is@>=1.0.0 <1.1.0",
+                                            "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                                        },
+                                        "isarray": {
+                                            "version": "0.0.1",
+                                            "from": "isarray@0.0.1",
+                                            "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                                        },
+                                        "string_decoder": {
+                                            "version": "0.10.31",
+                                            "from": "string_decoder@>=0.10.0 <0.11.0",
+                                            "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                                        },
+                                        "inherits": {
+                                            "version": "2.0.1",
+                                            "from": "inherits@>=2.0.1 <2.1.0",
+                                            "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                                        }
+                                    }
+                                },
+                                "xtend": {
+                                    "version": "3.0.0",
+                                    "from": "xtend@>=3.0.0 <3.1.0",
+                                    "resolved": "https://registry.npmjs.org/xtend/-/xtend-3.0.0.tgz"
+                                }
+                            }
+                        },
+                        "vinyl": {
+                            "version": "0.2.3",
+                            "from": "vinyl@>=0.2.1 <0.3.0",
+                            "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.2.3.tgz",
+                            "dependencies": {
+                                "clone-stats": {
+                                    "version": "0.0.1",
+                                    "from": "clone-stats@>=0.0.1 <0.1.0",
+                                    "resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz"
+                                }
+                            }
+                        }
+                    }
+                },
+                "lodash": {
+                    "version": "2.4.2",
+                    "from": "lodash@>=2.4.1 <2.5.0",
+                    "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz"
+                }
+            }
+        },
+        "octonode": {
+            "version": "0.6.18",
+            "from": "octonode@0.6.18",
+            "resolved": "https://registry.npmjs.org/octonode/-/octonode-0.6.18.tgz",
+            "dependencies": {
+                "request": {
+                    "version": "2.51.0",
+                    "from": "request@>=2.51.0 <2.52.0",
+                    "resolved": "https://registry.npmjs.org/request/-/request-2.51.0.tgz",
+                    "dependencies": {
+                        "bl": {
+                            "version": "0.9.4",
+                            "from": "bl@>=0.9.0 <0.10.0",
+                            "resolved": "https://registry.npmjs.org/bl/-/bl-0.9.4.tgz",
+                            "dependencies": {
+                                "readable-stream": {
+                                    "version": "1.0.33",
+                                    "from": "readable-stream@>=1.0.26 <1.1.0",
+                                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
+                                    "dependencies": {
+                                        "core-util-is": {
+                                            "version": "1.0.1",
+                                            "from": "core-util-is@>=1.0.0 <1.1.0",
+                                            "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                                        },
+                                        "isarray": {
+                                            "version": "0.0.1",
+                                            "from": "isarray@0.0.1",
+                                            "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                                        },
+                                        "string_decoder": {
+                                            "version": "0.10.31",
+                                            "from": "string_decoder@>=0.10.0 <0.11.0",
+                                            "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                                        },
+                                        "inherits": {
+                                            "version": "2.0.1",
+                                            "from": "inherits@>=2.0.1 <2.1.0",
+                                            "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "caseless": {
+                            "version": "0.8.0",
+                            "from": "caseless@>=0.8.0 <0.9.0",
+                            "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.8.0.tgz"
+                        },
+                        "forever-agent": {
+                            "version": "0.5.2",
+                            "from": "forever-agent@>=0.5.0 <0.6.0",
+                            "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.5.2.tgz"
+                        },
+                        "form-data": {
+                            "version": "0.2.0",
+                            "from": "form-data@>=0.2.0 <0.3.0",
+                            "resolved": "https://registry.npmjs.org/form-data/-/form-data-0.2.0.tgz",
+                            "dependencies": {
+                                "async": {
+                                    "version": "0.9.2",
+                                    "from": "async@>=0.9.0 <0.10.0",
+                                    "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz"
+                                },
+                                "mime-types": {
+                                    "version": "2.0.14",
+                                    "from": "mime-types@>=2.0.3 <2.1.0",
+                                    "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.14.tgz",
+                                    "dependencies": {
+                                        "mime-db": {
+                                            "version": "1.12.0",
+                                            "from": "mime-db@>=1.12.0 <1.13.0",
+                                            "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.12.0.tgz"
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "json-stringify-safe": {
+                            "version": "5.0.1",
+                            "from": "json-stringify-safe@>=5.0.0 <5.1.0",
+                            "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz"
+                        },
+                        "mime-types": {
+                            "version": "1.0.2",
+                            "from": "mime-types@>=1.0.1 <1.1.0",
+                            "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-1.0.2.tgz"
+                        },
+                        "node-uuid": {
+                            "version": "1.4.3",
+                            "from": "node-uuid@>=1.4.0 <1.5.0",
+                            "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.3.tgz"
+                        },
+                        "qs": {
+                            "version": "2.3.3",
+                            "from": "qs@>=2.3.1 <2.4.0",
+                            "resolved": "https://registry.npmjs.org/qs/-/qs-2.3.3.tgz"
+                        },
+                        "tunnel-agent": {
+                            "version": "0.4.1",
+                            "from": "tunnel-agent@>=0.4.0 <0.5.0",
+                            "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.1.tgz"
+                        },
+                        "tough-cookie": {
+                            "version": "2.0.0",
+                            "from": "tough-cookie@>=0.12.0",
+                            "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.0.0.tgz"
+                        },
+                        "http-signature": {
+                            "version": "0.10.1",
+                            "from": "http-signature@>=0.10.0 <0.11.0",
+                            "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-0.10.1.tgz",
+                            "dependencies": {
+                                "assert-plus": {
+                                    "version": "0.1.5",
+                                    "from": "assert-plus@>=0.1.5 <0.2.0",
+                                    "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz"
+                                },
+                                "asn1": {
+                                    "version": "0.1.11",
+                                    "from": "asn1@0.1.11",
+                                    "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz"
+                                },
+                                "ctype": {
+                                    "version": "0.5.3",
+                                    "from": "ctype@0.5.3",
+                                    "resolved": "https://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz"
+                                }
+                            }
+                        },
+                        "oauth-sign": {
+                            "version": "0.5.0",
+                            "from": "oauth-sign@>=0.5.0 <0.6.0",
+                            "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.5.0.tgz"
+                        },
+                        "hawk": {
+                            "version": "1.1.1",
+                            "from": "hawk@1.1.1",
+                            "resolved": "https://registry.npmjs.org/hawk/-/hawk-1.1.1.tgz",
+                            "dependencies": {
+                                "hoek": {
+                                    "version": "0.9.1",
+                                    "from": "hoek@>=0.9.0 <0.10.0",
+                                    "resolved": "https://registry.npmjs.org/hoek/-/hoek-0.9.1.tgz"
+                                },
+                                "boom": {
+                                    "version": "0.4.2",
+                                    "from": "boom@>=0.4.0 <0.5.0",
+                                    "resolved": "https://registry.npmjs.org/boom/-/boom-0.4.2.tgz"
+                                },
+                                "cryptiles": {
+                                    "version": "0.2.2",
+                                    "from": "cryptiles@>=0.2.0 <0.3.0",
+                                    "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-0.2.2.tgz"
+                                },
+                                "sntp": {
+                                    "version": "0.2.4",
+                                    "from": "sntp@>=0.2.0 <0.3.0",
+                                    "resolved": "https://registry.npmjs.org/sntp/-/sntp-0.2.4.tgz"
+                                }
+                            }
+                        },
+                        "aws-sign2": {
+                            "version": "0.5.0",
+                            "from": "aws-sign2@>=0.5.0 <0.6.0",
+                            "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.5.0.tgz"
+                        },
+                        "stringstream": {
+                            "version": "0.0.4",
+                            "from": "stringstream@>=0.0.4 <0.1.0",
+                            "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.4.tgz"
+                        },
+                        "combined-stream": {
+                            "version": "0.0.7",
+                            "from": "combined-stream@>=0.0.4 <0.1.0",
+                            "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz",
+                            "dependencies": {
+                                "delayed-stream": {
+                                    "version": "0.0.5",
+                                    "from": "delayed-stream@0.0.5",
+                                    "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz"
+                                }
+                            }
+                        }
+                    }
+                },
+                "randomstring": {
+                    "version": "1.0.7",
+                    "from": "randomstring@>=1.0.0 <2.0.0",
+                    "resolved": "https://registry.npmjs.org/randomstring/-/randomstring-1.0.7.tgz"
+                },
+                "deep-extend": {
+                    "version": "0.4.0",
+                    "from": "deep-extend@>=0.0.0 <1.0.0",
+                    "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.0.tgz"
+                }
+            }
+        },
+        "postcss": {
+            "version": "4.1.11",
+            "from": "postcss@4.1.11",
+            "resolved": "https://registry.npmjs.org/postcss/-/postcss-4.1.11.tgz",
+            "dependencies": {
+                "es6-promise": {
+                    "version": "2.1.1",
+                    "from": "es6-promise@>=2.1.1 <2.2.0",
+                    "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-2.1.1.tgz"
+                },
+                "js-base64": {
+                    "version": "2.1.8",
+                    "from": "js-base64@>=2.1.8 <2.2.0",
+                    "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.1.8.tgz"
+                }
+            }
+        },
+        "q": {
+            "version": "1.4.1",
+            "from": "q@1.4.1",
+            "resolved": "https://registry.npmjs.org/q/-/q-1.4.1.tgz"
+        },
+        "request": {
+            "version": "2.40.0",
+            "from": "request@2.40.0",
+            "resolved": "https://registry.npmjs.org/request/-/request-2.40.0.tgz",
+            "dependencies": {
+                "qs": {
+                    "version": "1.0.2",
+                    "from": "qs@>=1.0.0 <1.1.0",
+                    "resolved": "https://registry.npmjs.org/qs/-/qs-1.0.2.tgz"
+                },
+                "json-stringify-safe": {
+                    "version": "5.0.1",
+                    "from": "json-stringify-safe@>=5.0.0 <5.1.0",
+                    "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz"
+                },
+                "mime-types": {
+                    "version": "1.0.2",
+                    "from": "mime-types@>=1.0.1 <1.1.0",
+                    "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-1.0.2.tgz"
+                },
+                "forever-agent": {
+                    "version": "0.5.2",
+                    "from": "forever-agent@>=0.5.0 <0.6.0",
+                    "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.5.2.tgz"
+                },
+                "node-uuid": {
+                    "version": "1.4.3",
+                    "from": "node-uuid@>=1.4.0 <1.5.0",
+                    "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.3.tgz"
+                },
+                "tough-cookie": {
+                    "version": "2.0.0",
+                    "from": "tough-cookie@>=0.12.0",
+                    "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.0.0.tgz"
+                },
+                "form-data": {
+                    "version": "0.1.4",
+                    "from": "form-data@>=0.1.0 <0.2.0",
+                    "resolved": "https://registry.npmjs.org/form-data/-/form-data-0.1.4.tgz",
+                    "dependencies": {
+                        "combined-stream": {
+                            "version": "0.0.7",
+                            "from": "combined-stream@>=0.0.4 <0.1.0",
+                            "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz",
+                            "dependencies": {
+                                "delayed-stream": {
+                                    "version": "0.0.5",
+                                    "from": "delayed-stream@0.0.5",
+                                    "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz"
+                                }
+                            }
+                        },
+                        "mime": {
+                            "version": "1.2.11",
+                            "from": "mime@>=1.2.11 <1.3.0",
+                            "resolved": "https://registry.npmjs.org/mime/-/mime-1.2.11.tgz"
+                        },
+                        "async": {
+                            "version": "0.9.2",
+                            "from": "async@>=0.9.0 <0.10.0",
+                            "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz"
+                        }
+                    }
+                },
+                "tunnel-agent": {
+                    "version": "0.4.1",
+                    "from": "tunnel-agent@>=0.4.0 <0.5.0",
+                    "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.1.tgz"
+                },
+                "http-signature": {
+                    "version": "0.10.1",
+                    "from": "http-signature@>=0.10.0 <0.11.0",
+                    "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-0.10.1.tgz",
+                    "dependencies": {
+                        "assert-plus": {
+                            "version": "0.1.5",
+                            "from": "assert-plus@>=0.1.5 <0.2.0",
+                            "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz"
+                        },
+                        "asn1": {
+                            "version": "0.1.11",
+                            "from": "asn1@0.1.11",
+                            "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz"
+                        },
+                        "ctype": {
+                            "version": "0.5.3",
+                            "from": "ctype@0.5.3",
+                            "resolved": "https://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz"
+                        }
+                    }
+                },
+                "oauth-sign": {
+                    "version": "0.3.0",
+                    "from": "oauth-sign@>=0.3.0 <0.4.0",
+                    "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.3.0.tgz"
+                },
+                "hawk": {
+                    "version": "1.1.1",
+                    "from": "hawk@1.1.1",
+                    "resolved": "https://registry.npmjs.org/hawk/-/hawk-1.1.1.tgz",
+                    "dependencies": {
+                        "hoek": {
+                            "version": "0.9.1",
+                            "from": "hoek@>=0.9.0 <0.10.0",
+                            "resolved": "https://registry.npmjs.org/hoek/-/hoek-0.9.1.tgz"
+                        },
+                        "boom": {
+                            "version": "0.4.2",
+                            "from": "boom@>=0.4.0 <0.5.0",
+                            "resolved": "https://registry.npmjs.org/boom/-/boom-0.4.2.tgz"
+                        },
+                        "cryptiles": {
+                            "version": "0.2.2",
+                            "from": "cryptiles@>=0.2.0 <0.3.0",
+                            "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-0.2.2.tgz"
+                        },
+                        "sntp": {
+                            "version": "0.2.4",
+                            "from": "sntp@>=0.2.0 <0.3.0",
+                            "resolved": "https://registry.npmjs.org/sntp/-/sntp-0.2.4.tgz"
+                        }
+                    }
+                },
+                "aws-sign2": {
+                    "version": "0.5.0",
+                    "from": "aws-sign2@>=0.5.0 <0.6.0",
+                    "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.5.0.tgz"
+                },
+                "stringstream": {
+                    "version": "0.0.4",
+                    "from": "stringstream@>=0.0.4 <0.1.0",
+                    "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.4.tgz"
+                }
+            }
+        },
+        "source-map": {
+            "version": "0.4.2",
+            "from": "source-map@0.4.2",
+            "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.2.tgz",
+            "dependencies": {
+                "amdefine": {
+                    "version": "0.1.1",
+                    "from": "amdefine@>=0.0.4",
+                    "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.1.tgz"
+                }
+            }
+        },
+        "stylus": {
+            "version": "0.51.1",
+            "from": "stylus@0.51.1",
+            "resolved": "https://registry.npmjs.org/stylus/-/stylus-0.51.1.tgz",
+            "dependencies": {
+                "css-parse": {
+                    "version": "1.7.0",
+                    "from": "css-parse@>=1.7.0 <1.8.0",
+                    "resolved": "https://registry.npmjs.org/css-parse/-/css-parse-1.7.0.tgz"
+                },
+                "mkdirp": {
+                    "version": "0.3.5",
+                    "from": "mkdirp@>=0.3.0 <0.4.0",
+                    "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.5.tgz"
+                },
+                "debug": {
+                    "version": "2.2.0",
+                    "from": "debug@*",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+                    "dependencies": {
+                        "ms": {
+                            "version": "0.7.1",
+                            "from": "ms@0.7.1",
+                            "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
+                        }
+                    }
+                },
+                "sax": {
+                    "version": "0.5.8",
+                    "from": "sax@>=0.5.0 <0.6.0",
+                    "resolved": "https://registry.npmjs.org/sax/-/sax-0.5.8.tgz"
+                },
+                "glob": {
+                    "version": "3.2.11",
+                    "from": "glob@>=3.2.0 <3.3.0",
+                    "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
+                    "dependencies": {
+                        "inherits": {
+                            "version": "2.0.1",
+                            "from": "inherits@>=2.0.0 <3.0.0",
+                            "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                        },
+                        "minimatch": {
+                            "version": "0.3.0",
+                            "from": "minimatch@>=0.3.0 <0.4.0",
+                            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
+                            "dependencies": {
+                                "lru-cache": {
+                                    "version": "2.6.5",
+                                    "from": "lru-cache@>=2.0.0 <3.0.0",
+                                    "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.5.tgz"
+                                },
+                                "sigmund": {
+                                    "version": "1.0.1",
+                                    "from": "sigmund@>=1.0.0 <1.1.0",
+                                    "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz"
+                                }
+                            }
+                        }
+                    }
+                },
+                "source-map": {
+                    "version": "0.1.43",
+                    "from": "source-map@>=0.1.0 <0.2.0",
+                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
+                    "dependencies": {
+                        "amdefine": {
+                            "version": "0.1.1",
+                            "from": "amdefine@>=0.0.4",
+                            "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.1.tgz"
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/package.json
+++ b/package.json
@@ -21,18 +21,18 @@
         "url": "http://groovecoder.com"
     }],
     "dependencies": {
-        "body-parser": "^1.6.6",
-        "doiuse": "^1.0.2",
-        "express": "^4.8.6",
+        "body-parser": "1.6.6",
+        "doiuse": "1.0.2",
+        "express": "4.8.6",
         "gulp": "3.8.11",
         "gulp-file-include": "0.11.0",
         "gulp-marked": "1.0.0",
         "octonode": "0.6.18",
-        "postcss": "^4.1.11",
+        "postcss": "4.1.11",
         "q": "1.4.1",
-        "request": "^2.40.0",
-        "source-map": "^0.4.2",
-        "stylus": "^0.51.1"
+        "request": "2.40.0",
+        "source-map": "0.4.2",
+        "stylus": "0.51.1"
     },
     "devDependencies": {
         "gulp-jsbeautifier": "0.0.8",


### PR DESCRIPTION
The built-in "shrinkwrap" command is used. I also considered
npm-shrinkwrap [1] and lockdown [2] but encountered problems with both
during testing. The built-in "shrinkwrap" command is less robust, but
more stable.

[1] https://www.npmjs.com/package/npm-shrinkwrap
[2] https://www.npmjs.com/package/lockdown