### PR TITLE
Explicitly defining which node version we want to use on heroku

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,9 @@
         "postinstall": "./gulp --gulpfile gulpfile-prod.js build",
         "test": "./gulp test"
     },
+    "engines":  {
+        "node": "0.12.x"
+    },
     "license": "MPL-2.0",
     "contributors": [{
         "name": "Blixa Morgan",


### PR DESCRIPTION
For the sake of consistency, we should define node versions.