### PR TITLE
Fix #104: Rate-limit comment submissions

### DIFF
--- a/config.js
+++ b/config.js
@@ -1,6 +1,7 @@
 var config = {
     userAgent: 'Discord',
     token: process.env.OAUTH_TOKEN,
+    commentWait: process.env.COMMENT_WAIT || 50,
 
     // Used when no environment variable (process.env.PORT) is set
     port: 3000,

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
         "gulp": "^3.8.11",
         "gulp-file-include": "^0.11.0",
         "gulp-marked": "^1.0.0",
+        "limiter": "^1.0.5",
         "octonode": "^0.7.1",
         "postcss": "^4.1.11",
         "q": "^1.4.1",


### PR DESCRIPTION
Testing instructions:
1. Push this branch to your personal Heroku
2. `heroku config:set COMMENT_WAIT=50`
3. Push [this configuration](https://raw.githubusercontent.com/openjck/discord-test/master/.doiuse) to your test repo
4. Submit a pull request to add [this file](https://raw.githubusercontent.com/openjck/discord-test/master/incompatible.css)

Discord should comment on every incompatible line, with 20 comments total. It might take a few seconds for all of the comments to appear.
