### PR TITLE
Stop using deprecated bodyParser constructor

### DIFF
--- a/app.js
+++ b/app.js
@@ -2,20 +2,27 @@
 
 var path = require('path');
 
+var express = require('express');
+var bodyParser = require('body-parser');
+
 var hook = require('./hook');
 var config = require('./config');
 var logger = require('./logger');
 
-// Set up Express
-var express = require('express');
-var bodyParser = require('body-parser');
 var port = process.env.PORT || config.port;
 
+// Set up Express
 var app = express();
-app.use(bodyParser());
+app.use(bodyParser.urlencoded({
+    extended: true
+}));
+app.use(bodyParser.json());
+
+// Serve the homepage
 app.use(express.static(path.join(__dirname, 'build/www')));
+
+// Handle webhook POSTs
 app.post('/hook', hook.handle);
 
 exports.listener = app.listen(port);
-
 logger.info('Listening at port:', port);


### PR DESCRIPTION
This resolves the following warnings we were seeing in test output:

```
body-parser deprecated bodyParser: use individual json/urlencoded middlewares app.js:15:9
body-parser deprecated undefined extended: provide extended option node_modules/body-parser/index.js:75:29
```
