### PR TITLE
Manually sever connection to the server in tests

### DIFF
--- a/app.js
+++ b/app.js
@@ -15,6 +15,7 @@ var app = express();
 app.use(bodyParser());
 app.use(express.static(path.join(__dirname, 'build/www')));
 app.post('/hook', hook.handle);
-app.listen(port);
+
+exports.listener = app.listen(port);
 
 logger.info('Listening at port:', port);

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -26,12 +26,5 @@ gulp.task('test:mocha', function() {
     // The two `once` functions have been added because the gulp process
     // doesn't always finish if there's an error or feedback condition:
     // https://www.npmjs.com/package/gulp-mocha#test-suite-not-exiting
-    gulp.src('tests/tests.js')
-        .pipe(mocha())
-        .once('error', function() {
-            process.exit(1);
-        })
-        .once('end', function() {
-            process.exit();
-        });
+    gulp.src('tests/tests.js').pipe(mocha());
 });

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -131,6 +131,15 @@ describe('Discord Tests', function() {
                 });
         }
     });
+
+    /**
+     * We need to do cleanup so that the tests don't hang
+     */
+    describe('Test Cleanup', function() {
+        it('Server closes properly', function() {
+            app.listener.close();
+        });
+    });
 });
 
 


### PR DESCRIPTION
The `once` calls were masking a test issue for @openjck so it's best to sever open connections instead of killing the process.