### PR TITLE
Fix #104: Manage, throttle comments with Redis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,3 +2,6 @@ language: node_js
 
 node_js:
   - "0.12"
+
+services:
+  - redis-server

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,7 +11,10 @@ the contribution workflow at this point.
    create a token
 4. From the terminal, add your newly created GitHub personal access token to the
    Heroku config:  heroku config:set OAUTH_TOKEN=#######
-5. Create a test repository which you'll send invalid CSS or Stylus files to,
+5. Enable the Heroku Redis add-on (you may need to enter a credit card for
+   verification): `heroku addons:create heroku-redis:hobby-dev`
+6. Start a worker: `heroku ps:scale worker=1`
+7. Create a test repository which you'll send invalid CSS or Stylus files to,
    which your Discord instance will evaluate. Within that repository:
     1. Navigate to *Settings* > *Webhooks and Services*
     2. Add a webhook
@@ -27,9 +30,24 @@ GitHub.
 
 # Submitting a pull request
 
-Before submitting a pull request, run the following commands to test your
-changes and spruce things up.
+Before submitting a pull request, follow these steps to spruce things up and
+test your changes.
 
-1. `npm install`
-2. `./gulp test`
-3. `./gulp beautify`
+## Setup
+
+To get started, install all dependencies and set up Redis:
+
+1. Run `npm install`
+2. Follow [these steps](http://redis.io/topics/quickstart#installing-redis)
+   to install a local Redis server
+
+## Beautify your code
+
+Run this command to format your code according to our conventions:
+
+`./gulp beautify`
+
+## Run tests
+
+1. Start the local Redis server
+2. Run `./gulp test`

--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,2 @@
+web: node bin/www.js
+worker: node worker.js

--- a/config.js
+++ b/config.js
@@ -2,6 +2,8 @@ var config = {
     brand: 'Discord',
     token: process.env.OAUTH_TOKEN,
     trackingID: process.env.TRACKING_ID,
+    commentWait: process.env.COMMENT_WAIT || 250,
+    commentAttempts: process.env.COMMENT_ATTEMPTS || 10,
 
     // Used when no environment variable (process.env.PORT) is set
     port: 3000,

--- a/package.json
+++ b/package.json
@@ -3,7 +3,6 @@
     "main": "app.js",
     "private": true,
     "scripts": {
-        "start": "node ./bin/www",
         "postinstall": "./gulp --gulpfile gulpfile-prod.js build",
         "test": "./gulp test"
     },
@@ -34,6 +33,7 @@
         "express": "^4.8.6",
         "gulp": "^3.8.11",
         "gulp-marked": "^1.0.0",
+        "kue": "^0.9.4",
         "newrelic": "^1.21.1",
         "nunjucks": "^1.3.4",
         "octonode": "^0.7.1",

--- a/redisQueue.js
+++ b/redisQueue.js
@@ -1,0 +1,32 @@
+/**
+ * Return an instance of the Kue queue singleton.
+ *
+ * This file is only needed to work around bug #681 of Kue:
+ * https://github.com/Automattic/kue/issues/681
+ *
+ * Once the bugfix is shipped, we'll be able to get the queue with much less
+ * code, making this file unnecessary:
+ *
+ *     var kue = require('kue');
+ *     var redisQueue = kue.createQueue({
+ *         redis: process.env.REDIS_URL
+ *     });
+ */
+
+var kue = require('kue');
+var url = require('url');
+
+var parsedRedisURL = url.parse(process.env.REDIS_URL);
+
+var config = {
+    redis: {
+        port: parseInt(parsedRedisURL.port),
+        host: parsedRedisURL.hostname
+    }
+};
+
+if (parsedRedisURL.auth) {
+    config.redis.auth = parsedRedisURL.auth.replace(/.*?:/, '');
+}
+
+module.exports = kue.createQueue(config);

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -1,14 +1,19 @@
 'use strict';
 
-// Set environment variables that will be read during testing. These values will
-// be read in config.js, so they need to be set before the file is loaded.
+// Set environment variables that will be needed during testing. These values
+// will be read in config.js, so they need to be set before the file is loaded.
 var testedTrackingID = '654321';
 process.env.TRACKING_ID = testedTrackingID;
+process.env.REDIS_URL = 'redis://localhost';
+process.env.COMMENT_WAIT = 0; // The comment wait is only needed in production to avoid tripping a GitHub spam protection system
 
 // Pretend that we're running in production mode so that we can test
 // production-only features like Google Analytics tracking. This value is read
 // in app.js, so it needs to be set before the file is loaded.
 process.env.NODE_ENV = 'production';
+
+// Process Redis tasks
+require('../worker');
 
 var fs = require('fs');
 var path = require('path');

--- a/worker.js
+++ b/worker.js
@@ -1,0 +1,25 @@
+'use strict';
+
+var commenter = require('./commenter');
+var config = require('./config');
+var redisQueue = require('./redisQueue');
+
+var lastCommentTimestamp = 0;
+
+// Process comment jobs
+// Pause for commentWait milleseconds between comment submissions
+redisQueue.process('comment', function(job, done) {
+    var now = Date.now();
+    var waitRemaining = 0;
+
+    var nextCommentTimestamp = lastCommentTimestamp + parseInt(config.commentWait);
+
+    if (nextCommentTimestamp > now) {
+        waitRemaining = nextCommentTimestamp - now;
+    }
+
+    setTimeout(function() {
+        commenter.postPullRequestComment(job.data.commentURL, job.data.comment, job.data.filename, job.data.sha, job.data.line, done);
+        lastCommentTimestamp = Date.now(); // Use a new, fresh timestamp
+    }, waitRemaining);
+});


### PR DESCRIPTION
Testing these changes:
1. Push this to your personal Heroku
2. `heroku addons:create heroku-redis:hobby-dev` (you'll need to enter a credit card)
3. `heroku ps:scale web=1 worker=1`
4. Push [this .doiuse file](https://raw.githubusercontent.com/openjck/discord-test/master/.doiuse) to your test repo master branch
5. Submit a pull request to your test repo that adds [this file](https://raw.githubusercontent.com/openjck/discord-test/master/incompatible.css)

You should see 20 comments appear within a few seconds. There should be one comment for each property.

To run tests locally, see the updates in `CONTRIBUTING.md`.
