### PR TITLE
Support environment-specific configuration

### DIFF
--- a/app.js
+++ b/app.js
@@ -28,8 +28,8 @@ env = nunjucks.configure('views', {
 });
 
 // Global template variables
-env.addGlobal('brand', config.brand);
-env.addGlobal('trackingID', config.trackingID);
+env.addGlobal('brand', config('brand'));
+env.addGlobal('trackingID', config('trackingID'));
 env.addGlobal('NODE_ENV', process.env.NODE_ENV);
 
 app.use('/', index);

--- a/bin/www.js
+++ b/bin/www.js
@@ -16,7 +16,7 @@ var logger = require('../lib/logger');
  * Get port from environment and store in Express.
  */
 
-var port = normalizePort(process.env.PORT || config.port);
+var port = normalizePort(config('port'));
 app.set('port', port);
 
 /**

--- a/lib/commenter.js
+++ b/lib/commenter.js
@@ -20,8 +20,8 @@ function postPullRequestComment(commentURL, comment, filename, commitSHA, line, 
         url: commentURL,
         method: 'POST',
         headers: {
-            'User-Agent': config.brand,
-            'Authorization': 'token ' + config.token
+            'User-Agent': config('brand'),
+            'Authorization': 'token ' + config('token')
         },
         body: JSON.stringify({
             body: comment,

--- a/lib/config.js
+++ b/lib/config.js
@@ -1,14 +1,39 @@
-var config = {
-    brand: 'Discord',
-    token: process.env.OAUTH_TOKEN,
-    trackingID: process.env.TRACKING_ID,
-    commentWait: process.env.COMMENT_WAIT || 250,
-    commentAttempts: process.env.COMMENT_ATTEMPTS || 10,
+'use strict';
 
-    // Used when no environment variable (process.env.PORT) is set
-    port: 3000,
-    host: 'localhost',
-    protocol: 'http:'
+var config = {
+    def: {
+        brand: 'Discord',
+        token: process.env.OAUTH_TOKEN,
+        commentAttempts: process.env.COMMENT_ATTEMPTS || 10,
+    },
+    development: {
+        port: 3000,
+        redisURL: 'redis://localhost'
+    },
+    test: {
+        protocol: 'http:',
+        host: 'localhost',
+        port: 3000,
+        trackingID: '654321',
+        commentWait: 0,
+        redisURL: 'redis://localhost'
+    },
+    production: {
+        port: process.env.PORT,
+        trackingID: process.env.TRACKING_ID,
+        commentWait: process.env.COMMENT_WAIT || 250,
+        redisURL: process.env.REDIS_URL
+    }
 };
 
-module.exports = config;
+function getConfigValue(name) {
+    var env = process.env.NODE_ENV || 'development';
+
+    if (config[env][name]) {
+        return config[env][name];
+    } else {
+        return config.def[name];
+    }
+}
+
+module.exports = getConfigValue;

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -3,7 +3,7 @@
 ['log', 'warn', 'error', 'info'].forEach(function(level) {
     exports[level] = function() {
         // Don't log anything during automated tests
-        if (process.env.RUNNING_TESTS) return;
+        if (process.env.NODE_ENV === 'test') return;
 
         var args = Array.prototype.slice.call(arguments);
         args.unshift('[' + level + ']');

--- a/lib/redisQueue.js
+++ b/lib/redisQueue.js
@@ -9,14 +9,16 @@
  *
  *     var kue = require('kue');
  *     var redisQueue = kue.createQueue({
- *         redis: process.env.REDIS_URL
+ *         redis: config('redisURL');
  *     });
  */
 
 var kue = require('kue');
 var url = require('url');
 
-var parsedRedisURL = url.parse(process.env.REDIS_URL);
+var config = require('./config');
+
+var parsedRedisURL = url.parse(config('redisURL'));
 
 var config = {
     redis: {

--- a/tests/recorder.js
+++ b/tests/recorder.js
@@ -18,9 +18,6 @@
 
 */
 
-process.env.REDIS_URL = 'redis://localhost';
-process.env.COMMENT_WAIT = 0; // The comment wait is only needed in production to avoid tripping a GitHub spam protection system
-
 var nock = require('nock');
 var fs = require('fs');
 var request = require('request');

--- a/tests/test-utils.js
+++ b/tests/test-utils.js
@@ -8,7 +8,7 @@ var config = require('../lib/config');
 module.exports = {
 
     // The host for local Discord
-    appHost: [config.protocol, '//', config.host, ':', config.port].join(''),
+    appHost: [config('protocol'), '//', config('host'), ':', config('port')].join(''),
 
     // Track hostname for GitHub
     githubHost: 'https://api.github.com',

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -1,16 +1,8 @@
 'use strict';
 
-// Set environment variables that will be needed during testing. These values
-// will be read in config.js, so they need to be set before the file is loaded.
-var testedTrackingID = '654321';
-process.env.TRACKING_ID = testedTrackingID;
-process.env.REDIS_URL = 'redis://localhost';
-process.env.COMMENT_WAIT = 0; // The comment wait is only needed in production to avoid tripping a GitHub spam protection system
-
-// Pretend that we're running in production mode so that we can test
-// production-only features like Google Analytics tracking. This value is read
-// in app.js, so it needs to be set before the file is loaded.
-process.env.NODE_ENV = 'production';
+// This value is read in config.js, so it needs to be set before the file is
+// loaded anywhere.
+process.env.NODE_ENV = 'test';
 
 // Process Redis tasks
 require('../worker');
@@ -30,7 +22,6 @@ var notFoundURL = testUtils.appHost + '/page-that-will-never-exist';
 
 // Announce that automated tests are being run just in case other parts of the
 // application want to behave differently
-process.env.RUNNING_TESTS = true;
 
 
 describe('Discord Tests', function() {
@@ -50,10 +41,10 @@ describe('Discord Tests', function() {
         // should have a unique title and the brand name separated by a pipe.
         it('Page titles are set correctly', function(done) {
             request(testUtils.appHost, function(error, response, body) {
-                assert.include(body, '<title>' + config.brand + '</title>');
+                assert.include(body, '<title>' + config('brand') + '</title>');
 
                 request(notFoundURL, function(error, response, body) {
-                    assert.include(body, ' | ' + config.brand + '</title>');
+                    assert.include(body, ' | ' + config('brand') + '</title>');
                     done();
                 });
             });
@@ -62,10 +53,10 @@ describe('Discord Tests', function() {
 
         it('The Google Analytics tracking code is present in pages', function(done) {
             request(testUtils.appHost, function(error, response, body) {
-                assert.include(body, testedTrackingID);
+                assert.include(body, config('trackingID'));
 
                 request(notFoundURL, function(error, response, body) {
-                    assert.include(body, testedTrackingID);
+                    assert.include(body, config('trackingID'));
                     done();
                 });
             });

--- a/views/base.html
+++ b/views/base.html
@@ -8,7 +8,7 @@
             <title>{{ brand }}</title>
         {% endif %}
         <script>
-            {% if NODE_ENV == 'production' %}
+            {% if NODE_ENV == 'production' or NODE_ENV == 'test' %}
                 // Google Analytics
                 (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
                 (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),

--- a/worker.js
+++ b/worker.js
@@ -12,7 +12,7 @@ redisQueue.process('comment', function(job, done) {
     var now = Date.now();
     var waitRemaining = 0;
 
-    var nextCommentTimestamp = lastCommentTimestamp + parseInt(config.commentWait);
+    var nextCommentTimestamp = lastCommentTimestamp + parseInt(config('commentWait'));
 
     if (nextCommentTimestamp > now) {
         waitRemaining = nextCommentTimestamp - now;


### PR DESCRIPTION
This need came up while writing Postgres tests. Setting environment
variables in test files is a real hack. These changes allow us to define
environment-specific configurations in config.js.