### PR TITLE
Fix #79: Never post the same comment twice

### DIFF
--- a/migrations/20160121091841-create-comment.js
+++ b/migrations/20160121091841-create-comment.js
@@ -1,0 +1,39 @@
+'use strict';
+module.exports = {
+    up: function(queryInterface, Sequelize) {
+        return queryInterface.createTable('Comments', {
+            id: {
+                allowNull: false,
+                autoIncrement: true,
+                primaryKey: true,
+                type: Sequelize.INTEGER
+            },
+            repo: {
+                type: Sequelize.TEXT
+            },
+            pr: {
+                type: Sequelize.INTEGER
+            },
+            filename: {
+                type: Sequelize.TEXT
+            },
+            line: {
+                type: Sequelize.INTEGER
+            },
+            feature: {
+                type: Sequelize.TEXT
+            },
+            createdAt: {
+                allowNull: false,
+                type: Sequelize.DATE
+            },
+            updatedAt: {
+                allowNull: false,
+                type: Sequelize.DATE
+            }
+        });
+    },
+    down: function(queryInterface, Sequelize) {
+        return queryInterface.dropTable('Comments');
+    }
+};

--- a/models/comment.js
+++ b/models/comment.js
@@ -1,0 +1,17 @@
+'use strict';
+module.exports = function(sequelize, DataTypes) {
+    var Comment = sequelize.define('Comment', {
+        repo: DataTypes.TEXT,
+        pr: DataTypes.INTEGER,
+        filename: DataTypes.TEXT,
+        line: DataTypes.INTEGER,
+        feature: DataTypes.TEXT
+    }, {
+        classMethods: {
+            associate: function(models) {
+                // associations can be defined here
+            }
+        }
+    });
+    return Comment;
+};

--- a/routes/hook/index.js
+++ b/routes/hook/index.js
@@ -70,36 +70,51 @@ function processPullRequest(destinationRepo, originRepo, originBranch, prNumber,
                 processor.process(githubClient, originRepo, originBranch, file, discordConfig, function(incompatibility) {
                     // Callback for handling an incompatible line of code
                     var line = diff.lineToIndex(file.patch, incompatibility.usage.source.start.line);
-                    var comment = incompatibility.featureData.title + ' not supported by: ' + incompatibility.featureData.missing;
+                    var filename = file.filename;
+                    var feature = incompatibility.featureData.title;
+                    var comment = feature + ' not supported by: ' + incompatibility.featureData.missing;
 
-                    var redisQueue = kue.createQueue({
-                        redis: config.redisURL
-                    });
+                    var alreadyCommented = commentExists(destinationRepo, prNumber, filename, line, feature);
+                    alreadyCommented.then(function(alreadyCommented) {
+                        if (!alreadyCommented) {
+                            var redisQueue = kue.createQueue({
+                                redis: config.redisURL
+                            });
 
-                    // Create a Redis job that will submit the comment
-                    var commentJob = redisQueue.create('comment', {
-                        commentURL: commentURL,
-                        sha: currentCommit.sha,
-                        filename: file.filename,
-                        line: line,
-                        comment: comment
-                    });
+                            // Create a Redis job that will submit the comment
+                            var commentJob = redisQueue.create('comment', {
+                                commentURL: commentURL,
+                                sha: currentCommit.sha,
+                                filename: filename,
+                                line: line,
+                                comment: comment
+                            });
 
-                    // If the comment is rejected, re-attempt several times with
-                    // exponentially longer waits between each attempt.
-                    commentJob.attempts(config.commentAttempts);
-                    commentJob.backoff({
-                        type: 'exponential'
-                    });
+                            // If the comment is rejected, re-attempt several times with
+                            // exponentially longer waits between each attempt.
+                            commentJob.attempts(config.commentAttempts);
+                            commentJob.backoff({
+                                type: 'exponential'
+                            });
 
-                    // If the comment is rejected after several attempts, log an
-                    // error.
-                    commentJob.on('failed', function() {
-                        logger.error('Error posting comment to line ' + line + ' of ' + file.filename + ' in ' + originRepo + ' pull request #' + prNumber);
-                    });
+                            // If the comment is rejected after several attempts, log an
+                            // error.
+                            commentJob.on('failed', function() {
+                                logger.error('Error posting comment to line ' + line + ' of ' + filename + ' in ' + originRepo + ' pull request #' + prNumber);
+                            });
 
-                    commentJob.save(function(error) {
-                        if (error) return logger.error(error);
+                            commentJob.save(function(error) {
+                                if (error) return logger.error(error);
+                            });
+
+                            models.Comment.create({
+                                repo: destinationRepo,
+                                pr: prNumber,
+                                filename: filename,
+                                line: line,
+                                feature: feature
+                            });
+                        }
                     });
                 });
 
@@ -173,6 +188,36 @@ function getCommitDetail(repo, sha) {
             deferred.resolve(commitDetail);
         }
     });
+
+    return deferred.promise;
+}
+
+function commentExists(repo, prNumber, filename, line, feature) {
+    var deferred = Q.defer();
+
+    models.Comment.count({
+        where: {
+            repo: repo,
+            pr: prNumber,
+            filename: filename,
+            line: line,
+            feature: feature
+        }
+    }).then(
+        // Success callback (a matching comment was found)
+        function(count) {
+            if (count > 0) {
+                deferred.resolve(true);
+            } else {
+                deferred.resolve(false);
+            }
+        },
+
+        // Failure callback (no matching comments were found)
+        function(error) {
+            deferred.reject(error);
+        }
+    );
 
     return deferred.promise;
 }


### PR DESCRIPTION
### Testing

1. Push this branch up to your test webhook
2. Open a pull request in the repo that uses the test webhook
3. Wait about 30 seconds, refresh, and note the number of comments
4. Close the pull request, reopen it, wait a few seconds, refresh, and note the number of comments

The number of comments should not change between step 3 and step 4. No lines should be double-commented.

### To do

- [ ] Add in-source comments
- [ ] Add tests
- [x] Merge with Luke's comment metrics work